### PR TITLE
[FEATURE](https://github.com/mersel-dss/mersel-dss-server-signer-java…

### DIFF
--- a/src/main/java/io/mersel/dss/signer/api/SignatureApplication.java
+++ b/src/main/java/io/mersel/dss/signer/api/SignatureApplication.java
@@ -5,6 +5,7 @@ import io.mersel.dss.signer.api.services.CertificateInfoService;
 import io.mersel.dss.signer.api.services.keystore.KeyStoreProvider;
 import io.mersel.dss.signer.api.services.keystore.PKCS11KeyStoreProvider;
 import io.mersel.dss.signer.api.services.keystore.PfxKeyStoreProvider;
+import org.apache.commons.lang3.math.NumberUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -72,6 +73,7 @@ public class SignatureApplication {
         try {
             // Environment variable'lardan yapılandırmayı oku
             String pkcs11Library = System.getenv("PKCS11_LIBRARY");
+            String pkcs11SlotListIndexStr = System.getenv("PKCS11_SLOT_LIST_INDEX");
             String pkcs11SlotStr = System.getenv("PKCS11_SLOT");
             String pfxPath = System.getenv("PFX_PATH");
             String pin = System.getenv("CERTIFICATE_PIN");
@@ -87,16 +89,16 @@ public class SignatureApplication {
             KeyStoreProvider provider;
             
             if (pkcs11Library != null && !pkcs11Library.isEmpty()) {
-                Long slot = (pkcs11SlotStr != null && !pkcs11SlotStr.isEmpty()) 
-                    ? Long.parseLong(pkcs11SlotStr) 
-                    : 0L;
-                
+                long slot = NumberUtils.isDigits(pkcs11SlotStr) ? Long.parseLong(pkcs11SlotStr):-1L;
+                long slotIndex = NumberUtils.isDigits(pkcs11SlotListIndexStr) ? Long.parseLong(pkcs11SlotListIndexStr):-1L;
+
                 System.out.println("📦 Keystore Type: PKCS#11");
                 System.out.println("📂 Library: " + pkcs11Library);
                 System.out.println("🎰 Slot: " + slot);
+                System.out.println("🎰 Slot List Index: " + slotIndex);
                 System.out.println();
                 
-                provider = new PKCS11KeyStoreProvider(pkcs11Library, slot);
+                provider = new PKCS11KeyStoreProvider(pkcs11Library, slot,slotIndex);
                 
             } else if (pfxPath != null && !pfxPath.isEmpty()) {
                 System.out.println("📦 Keystore Type: PFX/PKCS12");

--- a/src/main/java/io/mersel/dss/signer/api/config/SignatureConfiguration.java
+++ b/src/main/java/io/mersel/dss/signer/api/config/SignatureConfiguration.java
@@ -55,7 +55,8 @@ public class SignatureConfiguration {
         if (StringUtils.hasText(config.getPkcs11LibraryPath())) {
             return new PKCS11KeyStoreProvider(
                 config.getPkcs11LibraryPath(),
-                config.getPkcs11Slot()
+                config.getPkcs11Slot(),
+                config.getPkcs11SlotIndex()
             );
         }
         

--- a/src/main/java/io/mersel/dss/signer/api/controllers/CertificateInfoController.java
+++ b/src/main/java/io/mersel/dss/signer/api/controllers/CertificateInfoController.java
@@ -136,7 +136,8 @@ public class CertificateInfoController {
         if (StringUtils.hasText(config.getPkcs11LibraryPath())) {
             return new PKCS11KeyStoreProvider(
                 config.getPkcs11LibraryPath(),
-                config.getPkcs11Slot()
+                config.getPkcs11Slot(),
+                config.getPkcs11SlotIndex()
             );
         } else if (StringUtils.hasText(config.getPfxPath())) {
             return new PfxKeyStoreProvider(config.getPfxPath());

--- a/src/main/java/io/mersel/dss/signer/api/models/configurations/SignatureServiceConfiguration.java
+++ b/src/main/java/io/mersel/dss/signer/api/models/configurations/SignatureServiceConfiguration.java
@@ -15,6 +15,9 @@ public class SignatureServiceConfiguration {
     @Value("${PKCS11_SLOT:-1}")
     private Long pkcs11Slot;
 
+    @Value("${PKCS11_SLOT_LIST_INDEX:-1}")
+    private Long pkcs11SlotIndex;
+
     @Value("${CERTIFICATE_PIN}")
     private String certificatePin;
 
@@ -76,6 +79,10 @@ public class SignatureServiceConfiguration {
 
     public Long getPkcs11Slot() {
         return pkcs11Slot;
+    }
+
+    public Long getPkcs11SlotIndex() {
+        return pkcs11SlotIndex;
     }
 
     public String getIssuerCertificatePath() {


### PR DESCRIPTION
…/issues/4)

Provider slotListIndex ve slot parametrelerinin ayrı ayrı kullanılabilmesi sağlandı.

## 📝 Değişiklik Açıklaması

slotListIndex ve slot parametrelerinin ayrı ayrı kullanılabilmesi

## 🔗 İlgili Issue

Fixes #([4](https://github.com/mersel-dss/mersel-dss-server-signer-java/issues/4))

## 🎯 Değişiklik Türü

- [ ] 🐛 Bug fix (geriye uyumlu hata düzeltmesi)
- [x] ✨ Yeni özellik (geriye uyumlu yeni işlevsellik)
- [ ] 💥 Breaking change (geriye uyumsuz değişiklik)
- [ ] 📝 Dokümantasyon güncellesi
- [ ] ♻️ Refactoring (davranış değişikliği olmadan kod iyileştirme)
- [ ] ⚡ Performance iyileştirmesi
- [ ] 🧪 Test ekleme/güncelleme

## 🧪 Testler

- [ ] Yeni unit testler eklendi
- [ ] Mevcut testler güncellendi
- [ ] Tüm testler başarılı (`mvn test`)
- [ ] Manuel olarak test edildi

## 📋 Kontrol Listesi

- [x] Kod standartlarına uygun (Javadoc, isimlendirme)
- [x] Commit mesajları açıklayıcı
- [ ] CHANGELOG.md güncellendi (major değişiklikler için)
- [ ] README.md güncellendi (gerekirse)
- [x] Linter hataları yok
- [ ] Breaking change ise migration guide eklendi

## 💭 Ek Notlar

Reviewer'ların bilmesi gereken başka bir şey var mı?

ENV PKCS11_SLOT -> provider config içerisinde 'slot'
ENV PKCS11_SLOT_LIST_INDEX-> provider config içerisinde 'slotListIndex' 
değerine karşılık gelecek şekilde düzenleme yapıldı. Aynı anda ikisi birden tanımlı ve geçerli(>=0) olması halinde öncelikle slotListIndex dikkate alınacak şekilde tanımlandı.