### PR TITLE
E-adisyon raporu ve edöviz raporu(e-döviz iptal raporu hariç) zaman d…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,112 +7,159 @@ ve bu proje [Semantic Versioning](https://semver.org/spec/v2.0.0.html) kullanmak
 
 ## [Unreleased]
 
+### Changed (BREAKING)
+
+- **`POST /v1/xadessign`: imza profili (XADES_BES / XADES_A) tamamen request
+  parametresi ile belirlenir; `documentType` artık seviye kararına dahil
+  değildir.**
+  - **Davranış değişimi**: Önceki sürümde `documentType=EArchiveReport`
+    veya `documentType=EBiletReport` gönderildiğinde sistem **proaktif
+    olarak** XAdES-A seviyesine yükseltme yapıyordu (TSA çağrısı dahil).
+    Bu davranış kaldırıldı: rapor tipi gönderilse bile request'te
+    `signatureLevel=XADES_A` açıkça istenmediği sürece archive timestamp
+    eklenmez.
+  - **Migration**: e-Arşiv Raporu / e-Bilet Raporu akışı kullanan
+    client'lar artık aşağıdaki gibi explicit profil seçmek zorundadır:
+    ```
+    documentType=EArchiveReport
+    signatureLevel=XADES_A          # archive timestamp ekler (eski default)
+    ```
+    `signatureLevel` alanı omit edilirse veya `XADES_BES` gönderilirse
+    yalnızca baseline imza üretilir.
+  - **Mali sorumluluk notu**: e-Arşiv Raporu / e-Bilet Raporu gibi 10 yıllık
+    saklama gerektiren akışlarda `XADES_A` talebi artık çağıran tarafın
+    sorumluluğundadır. Pasif (implicit) XAdES-A davranışı kaldırıldığı
+    için, rapor üreten servislerin bu PR'a geçişte istek payload'unu
+    `signatureLevel=XADES_A` ekleyerek güncellemesi gerekir.
+  - **Niçin breaking yaptık**: Negatif boolean flag (`DisableTimestamp`)
+    yerine pozitif explicit enum, (a) GİB / ETSI nomenclature ile birebir
+    uyumlu, (b) Swagger UI'da self-documenting, (c) ileride XAdES-T,
+    XAdES-LT vb. baseline seviyelerine genişletmek için breaking change
+    üretmeden zemin sağlar. `DisableTimestamp` v1 API'sine merge
+    edilmeden bu refactor tercih edildi.
+
 ### Added
 
-- **`GET /api/certificates/signingCertificate` — aktif imzacı sertifikayı
-  base64 encoded biçimde de döndüren tek-shot endpoint.**
+- **Yeni `XadesSignatureLevel` enum (`XADES_BES`, `XADES_A`).**
+  - `SignXadesDto.SignatureLevel` alanı **non-null** kontrata sahip: omit
+    edilirse veya `null` set edilirse DTO setter/getter katmanı
+    `XADES_BES` default uygular. Swagger UI'da dropdown olarak görünür
+    ve `defaultValue=XADES_BES` ile dokümante edilir.
+  - **`XADES_BES`** (DSS `XAdES_BASELINE_B`): yalnızca imza; TSA
+    çağrılmaz, kontör harcanmaz. e-Fatura, e-Arşiv faturası, irsaliye,
+    uygulama yanıtı, HrXml ve **e-Adisyon raporu / e-Döviz raporu
+    (iptal hariç)** gibi timestamp gerektirmeyen tüm akışlar için
+    uygundur. **API'nin yeni default'udur.**
+  - **`XADES_A`** (DSS `XAdES_BASELINE_LTA`, legacy ETSI TS 101 903
+    terminolojisinde XAdES-A): imza + signature timestamp + archive
+    timestamp. e-Arşiv Raporu / e-Bilet Raporu gibi arşivsel akışlar
+    için uygundur. TSA yapılandırılmamışsa istek `TIMESTAMP_ERROR` ile
+    reddedilir (fail-fast, silent XAdES_BES fallback üretilmez).
+  - **Non-null sözleşmesi**: Service ve LevelUpgradeService imzaları
+    `null` kabul etmez; null safety DTO katmanında garanti edilir
+    (multipart binding edge case'inde alan boş gelse bile setter
+    `XADES_BES`'e düşürür).
+- `**GET /api/certificates/signingCertificate` — aktif imzacı sertifikayı
+base64 encoded biçimde de döndüren tek-shot endpoint.**
   - **Motivasyon**: Manuel XAdES imza akışı (özellikle GİB UBL-TR 2.1
-    için özel namespace prefix gereksinimi olan senaryolar)
-    `<ds:Signature>` elementini elle kuruyor; bu sırada
-    `<ds:X509Certificate>` elementine basılacak base64 encoded
-    sertifika için server'a tekrar tekrar dosya okuma / `/list`
-    endpoint'i + alias-serial filtreleme döngüsü yapmak zorunda
-    kalıyordu. `/list` çağrı başına token'daki tüm entry'leri döner
-    ve büyük HSM'lerde (50+ sertifika) gereksiz payload üretir.
+  için özel namespace prefix gereksinimi olan senaryolar)
+  `<ds:Signature>` elementini elle kuruyor; bu sırada
+  `<ds:X509Certificate>` elementine basılacak base64 encoded
+  sertifika için server'a tekrar tekrar dosya okuma / `/list`
+  endpoint'i + alias-serial filtreleme döngüsü yapmak zorunda
+  kalıyordu. `/list` çağrı başına token'daki tüm entry'leri döner
+  ve büyük HSM'lerde (50+ sertifika) gereksiz payload üretir.
   - **Mekanizma**: Yeni endpoint, Spring container'da başlangıçta
-    resolve edilmiş tek `SigningMaterial` singleton'ından beslenir.
-    Token'a fazladan istek atılmaz; sertifika materyali zaten
-    bootstrap'ta okunduğu için yanıt sub-millisecond düzeyde döner.
+  resolve edilmiş tek `SigningMaterial` singleton'ından beslenir.
+  Token'a fazladan istek atılmaz; sertifika materyali zaten
+  bootstrap'ta okunduğu için yanıt sub-millisecond düzeyde döner.
   - **Yanıt sözleşmesi**: `CertificateInfoDto` formatında — listing
-    endpoint'iyle birebir aynı şema. İki ek alan: `publicKeyAlgorithm`
-    (örn. `RSA`, `EC`) ve `base64EncodedCertificate` (X.509 DER
-    encoding'in base64'lenmiş hali). `hasPrivateKey` her zaman
-    `true` döner; HSM (PKCS#11) yapılandırmasında JCA katmanı private
-    key handle'ı `null` yansıtsa bile imza materyali fiilen token'da
-    yaşadığı için bilgilendirme doğru.
+  endpoint'iyle birebir aynı şema. İki ek alan: `publicKeyAlgorithm`
+  (örn. `RSA`, `EC`) ve `base64EncodedCertificate` (X.509 DER
+  encoding'in base64'lenmiş hali). `hasPrivateKey` her zaman
+  `true` döner; HSM (PKCS#11) yapılandırmasında JCA katmanı private
+  key handle'ı `null` yansıtsa bile imza materyali fiilen token'da
+  yaşadığı için bilgilendirme doğru.
   - **Cache sözleşmesi**: `SigningMaterial` başlangıçta resolve
-    edildiği için içerik uygulama yaşam döngüsü boyunca **değişmez**.
-    Yanıt `Cache-Control: private, max-age=3600, immutable` header'ı
-    taşır; reverse-proxy ve client tarafı in-memory cache'ler tekrarlı
-    çağrılarda 0-RTT lookup yapabilir.
+  edildiği için içerik uygulama yaşam döngüsü boyunca **değişmez**.
+  Yanıt `Cache-Control: private, max-age=3600, immutable` header'ı
+  taşır; reverse-proxy ve client tarafı in-memory cache'ler tekrarlı
+  çağrılarda 0-RTT lookup yapabilir.
   - **Listing endpoint hijenı**: `base64EncodedCertificate` alanı
-    `/list` yanıtında kasıtlı olarak `null` bırakılır — 50+ sertifika
-    içeren HSM'lerde payload'un 100 KB+'a şişmesini önler. Manuel
-    XAdES kullanan akışlar `/signingCertificate`'a yönlendirilir.
+  `/list` yanıtında kasıtlı olarak `null` bırakılır — 50+ sertifika
+  içeren HSM'lerde payload'un 100 KB+'a şişmesini önler. Manuel
+  XAdES kullanan akışlar `/signingCertificate`'a yönlendirilir.
 
 ### Fixed
 
-- **`CertificateInfoService` listing yolunda iki minör regresyon
-  kapatıldı.**
+- `**CertificateInfoService` listing yolunda iki minör regresyon
+kapatıldı.**
   - **Belirti 1**: Helper'a çıkarılan `convertToCertificateInfoDto(...)`
-    sonrası `cert == null` durumu yalnızca NPE → catch → warn log
-    pattern'iyle yakalanıyordu; exception ile kontrol akışı.
-    **Çözüm**: Null sertifika explicit `continue` ile sessizce
-    atlanır, debug seviyesi log düşer.
+  sonrası `cert == null` durumu yalnızca NPE → catch → warn log
+  pattern'iyle yakalanıyordu; exception ile kontrol akışı.
+  **Çözüm**: Null sertifika explicit `continue` ile sessizce
+  atlanır, debug seviyesi log düşer.
   - **Belirti 2**: Refactor sırasında `keyStore.isCertificateEntry()`
-    ve `keyStore.isKeyEntry()` çağrıları per-alias try-catch dışına
-    çıkmıştı; bu metotlar legacy/bozuk keystore entry'lerinde
-    `KeyStoreException` atabildiği için tek bir kötü alias tüm
-    listing'i patlatıyordu. **Çözüm**: Tüm alias-bazlı okuma adımları
-    tek try ile sarmalandı — eski "sessiz skip" davranışı korundu.
-
-- **`CertificateInfoDto.toString()` log satırı başına 1.5–2 KB
-  şişmesin diye base64 sertifika kasıtlı olarak değer yerine
-  uzunlukla loglanır.** Aksi halde DTO'nun debug seviyesinde
-  loglandığı yerlerde her satır devasa base64 string içerir; 0.7.0'da
-  gelen `LogHeadersFilter` ile birlikte log dosya boyutları görünür
-  şekilde patlardı.
-
-- **`scripts/check-changelog-updated.sh` awk regex'inde gizli bug
-  düzeltildi — her PR yanlışlıkla "CHANGELOG güncellenmemiş" hatası
-  alıyordu.**
+  ve `keyStore.isKeyEntry()` çağrıları per-alias try-catch dışına
+  çıkmıştı; bu metotlar legacy/bozuk keystore entry'lerinde
+  `KeyStoreException` atabildiği için tek bir kötü alias tüm
+  listing'i patlatıyordu. **Çözüm**: Tüm alias-bazlı okuma adımları
+  tek try ile sarmalandı — eski "sessiz skip" davranışı korundu.
+- `**CertificateInfoDto.toString()` log satırı başına 1.5–2 KB
+şişmesin diye base64 sertifika kasıtlı olarak değer yerine
+uzunlukla loglanır.** Aksi halde DTO'nun debug seviyesinde
+loglandığı yerlerde her satır devasa base64 string içerir; 0.7.0'da
+gelen `LogHeadersFilter` ile birlikte log dosya boyutları görünür
+şekilde patlardı.
+- `**scripts/check-changelog-updated.sh` awk regex'inde gizli bug
+düzeltildi — her PR yanlışlıkla "CHANGELOG güncellenmemiş" hatası
+alıyordu.**
   - **Belirti**: `Verify CHANGELOG.md is updated` GitHub Actions
-    check'i, [Unreleased] bölümüne entry ekleyen PR'larda dahi
-    "[Unreleased] bolumune yeni satir eklenmemis gibi gorunuyor"
-    hatası veriyordu. Hasan'ın PR #20 commit'i ve önceki
-    `feat(observability)` commit'i (`54c8ce0`) hep aynı false
-    positive ile fail dönüyordu; production'a etkisiz çünkü doğrudan
-    main'e push edilen commit'lerde CI failure merge'i engellemiyor,
-    ama PR akışında engelleyici.
+  check'i, [Unreleased] bölümüne entry ekleyen PR'larda dahi
+  "[Unreleased] bolumune yeni satir eklenmemis gibi gorunuyor"
+  hatası veriyordu. Hasan'ın PR #20 commit'i ve önceki
+  `feat(observability)` commit'i (`54c8ce0`) hep aynı false
+  positive ile fail dönüyordu; production'a etkisiz çünkü doğrudan
+  main'e push edilen commit'lerde CI failure merge'i engellemiyor,
+  ama PR akışında engelleyici.
   - **Kök neden**: Awk pattern `/^[+\-] ## \[Unreleased\]/` iki
-    sorunu birden taşıyordu. (a) Unified diff format'ında marker
-    (`+`/`-`) ile içerik arasında boşluk yoktur (`+## ...`), ama
-    pattern literal boşluk bekliyordu. (b) Mevcut `## [Unreleased]`
-    header'ı, eklemeler altına yapıldığı için diff'te **context
-    satır** (` ## [Unreleased]`, space-prefix'li) olarak görünür;
-    karakter sınıfı `[+\-]` boşluğu kapsamadığı için context satır
-    zone'a hiç giremezdi. Sonuç: pattern fiilen hiçbir gerçek diff
-    formatında match etmez.
+  sorunu birden taşıyordu. (a) Unified diff format'ında marker
+  (`+`/`-`) ile içerik arasında boşluk yoktur (`+## ...`), ama
+  pattern literal boşluk bekliyordu. (b) Mevcut `## [Unreleased]`
+  header'ı, eklemeler altına yapıldığı için diff'te **context
+  satır** ( `## [Unreleased]`, space-prefix'li) olarak görünür;
+  karakter sınıfı `[+\-]` boşluğu kapsamadığı için context satır
+  zone'a hiç giremezdi. Sonuç: pattern fiilen hiçbir gerçek diff
+  formatında match etmez.
   - **Çözüm**: Zone trigger karakter sınıfı `[+\- ]`'ye genişletildi
-    (space dahil), marker ile `##` arasındaki literal boşluk
-    kaldırıldı, zone exit pattern'i `## [0-9]` ile sürüm-numaralı
-    section'lara odaklandı (yine "Unreleased" yakalanmasın diye).
-    Doğrulama: mevcut PR + iki geçmiş feature commit (`54c8ce0`,
-    `a9ae7dd`) artık PASSED dönerken, CHANGELOG güncellemesi
-    olmayan saf-kod commit'i (Hasan'ın orijinal `880c784` commit'i)
-    hâlâ doğru şekilde FAILED veriyor — negatif case korundu.
-
-- **`integration-tests.yml` workflow'undaki `XadesSoftHsmVerifierE2ETest`
-  iterasyon sayısı 25 → 20 olarak güncellendi.**
+  (space dahil), marker ile `##` arasındaki literal boşluk
+  kaldırıldı, zone exit pattern'i `## [0-9]` ile sürüm-numaralı
+  section'lara odaklandı (yine "Unreleased" yakalanmasın diye).
+  Doğrulama: mevcut PR + iki geçmiş feature commit (`54c8ce0`,
+  `a9ae7dd`) artık PASSED dönerken, CHANGELOG güncellemesi
+  olmayan saf-kod commit'i (Hasan'ın orijinal `880c784` commit'i)
+  hâlâ doğru şekilde FAILED veriyor — negatif case korundu.
+- `**integration-tests.yml` workflow'undaki `XadesSoftHsmVerifierE2ETest`
+iterasyon sayısı 25 → 20 olarak güncellendi.**
   - **Belirti**: 0.7.0 release'inde `XadesDocumentFixture.standardFixtures()`
-    fixture listesi 5'ten 4'e düşürüldü (EARSIV_RAPORU XAdES-A TSA
-    zorunluluğu nedeniyle hariç tutuldu; bkz. yukarıdaki XAdES fail-fast
-    sözleşmesi). Ancak CI workflow'undaki assertion (`expected=25`,
-    "5 PfxTestKey × 5 XadesDocumentFixture") güncellenmediği için
-    HSM integration check her PR'da fail veriyor (gerçek: 20, beklenen: 25).
+  fixture listesi 5'ten 4'e düşürüldü (EARSIV_RAPORU XAdES-A TSA
+  zorunluluğu nedeniyle hariç tutuldu; bkz. yukarıdaki XAdES fail-fast
+  sözleşmesi). Ancak CI workflow'undaki assertion (`expected=25`,
+  "5 PfxTestKey × 5 XadesDocumentFixture") güncellenmediği için
+  HSM integration check her PR'da fail veriyor (gerçek: 20, beklenen: 25).
   - **Görünmezlik sebebi**: 0.7.0 commit'i (`10ed0a6`) doğrudan main'e
-    push edildiği için CI failure merge'i engellemedi; bug ilk PR
-    (#20) main'e rebase olunca yüzeye çıktı.
+  push edildiği için CI failure merge'i engellemedi; bug ilk PR
+  (#20) main'e rebase olunca yüzeye çıktı.
   - **Çözüm**: `expected=20`, açıklama yorumlarında "5 × 4 = 20"
-    matematiği netleştirildi, hem step adındaki "(25 HSM+verifier
-    iterations)" başlığı hem üst seviye workflow header'ı 0.7.0
-    fixture daralmasına atıfla güncellendi.
+  matematiği netleştirildi, hem step adındaki "(25 HSM+verifier
+  iterations)" başlığı hem üst seviye workflow header'ı 0.7.0
+  fixture daralmasına atıfla güncellendi.
 
 ## [0.7.0] - 2026-05-25
 
 ### Added
 
-- **`x-log-*` request header'ları artık tüm log satırlarında JSON olarak
+- `**x-log-`* request header'ları artık tüm log satırlarında JSON olarak
 otomatik görünür — opt-in correlation/trace observability sözleşmesi.**
   - **Motivasyon**: Operatör, çağıran sistemden gelen takip metadatasını
   (örn. `X-Log-Id: abc`, `X-Log-Kimlik: kajsdh`) controller / service
@@ -126,7 +173,7 @@ otomatik görünür — opt-in correlation/trace observability sözleşmesi.**
   tüm header'ları (case-insensitive) yakalayıp SLF4J `MDC`'ye
   `xlog.<lower-case-name>` formunda yazar. Yeni `LogHeadersConverter`
   Logback `ClassicConverter`'ı pattern içinde `%xLogHeaders` olarak
-  kayıtlı; her log event'inde `xlog.*` MDC entry'lerini alfabetik
+  kayıtlı; her log event'inde `xlog.`* MDC entry'lerini alfabetik
   sırada JSON nesnesine serialize eder. Hiç header yoksa boş string
   döner — mevcut log gürültüsü artmaz.
   - **Çıktı formatı**: `xlog={"x-log-id":"abc","x-log-kimlik":"kajsdh"}`.
@@ -134,13 +181,13 @@ otomatik görünür — opt-in correlation/trace observability sözleşmesi.**
   CONSOLE / `application.log` / `error.log` / `signature.log`
   appender'larının hepsi yeni pattern'i kullanır.
   - **Güvenlik sertleştirmesi**: (a) request başına en fazla
-  20 `x-log-*` header işlenir — şişirilmiş header bombasına karşı
+  20 `x-log-`* header işlenir — şişirilmiş header bombasına karşı
   sınır; (b) her değer 512 karaktere kırpılır; (c) CR/LF + diğer
   ASCII kontrol karakterleri boşluğa çevrilir — klasik CRLF log
   injection vektörü kapatılır; (d) converter ikinci savunma hattı
   olarak `<0x20` kontrol karakterlerini RFC 8259 JSON kaçışına
   uğratır.
-  - **MDC sözleşmesi**: Filter sadece kendi koyduğu `xlog.*`
+  - **MDC sözleşmesi**: Filter sadece kendi koyduğu `xlog.`*
   anahtarlarını `finally` bloğunda temizler — uygulamanın başka bir
   yerinde MDC'ye konmuş tenant/trace anahtarları korunur.
   - **Async sınırlama**: SLF4J MDC thread-local; `@Async` ya da
@@ -678,7 +725,7 @@ versioning, CHANGELOG-driven release notes**
   `mvn test+package`, release commit, annotated/signed tag).
   `--dry-run`, `--yes`, `--no-build`, `--no-test`, `--skip-clean` flag'leri.
   Push'u kullanıcıya bırakır; REMOTE'a otomatik bir şey gitmez.
-  - `**scripts/bump-version.sh**`: `pom.xml` proje-level `<version>` bumper.
+  - `**scripts/bump-version.sh`**: `pom.xml` proje-level `<version>` bumper.
   `major`/`minor`/`patch`/`rc` ya da explicit SemVer geçilir. Parent
   block'a dokunmaz (Spring Boot `2.7.18` korunur). SemVer 2.0.0 validation.
   - `**scripts/extract-release-notes.sh**`: CHANGELOG.md'den ilgili
@@ -729,7 +776,7 @@ iki job'unun yerel karşılığı).
   `/opt/homebrew/lib/softhsm/libsofthsm2.{so,dylib}`, Intel `/usr/local/`,
   Linux `/usr/lib/`) → `mvn validate` → `mvn test -Dgroups=pkcs11-integration`
   → workflow'un test-count guardrail'leri (6 + 25 iterasyon).
-  - `**--verifier-e2e**`: Docker daemon check → GHCR `:main` pull (veya
+  - `**--verifier-e2e`**: Docker daemon check → GHCR `:main` pull (veya
   `--build-verifier` ile sibling `mersel-dss-verifier-api-java` repo'sundan
   source build) → `mvn test -Dgroups=verifier-e2e -DverifierImage=...`
   → 277 iterasyon guard.
@@ -779,7 +826,7 @@ iki job'unun yerel karşılığı).
   `TRUSTED_ROOT_CERT_FOLDER_PATH` ve `CORS_ALLOWED_ORIGINS`'ı kapsıyor;
   README'deki var olmayan `start-test-kurum{1,2,3}` dosya referansları
   gerçekteki parametreli `start-test-kurum.{sh,ps1}` script'iyle hizalandı.
-  - `**devops/README.md**` sıfırdan yazıldı: 4-yollu deployment karar matrisi
+  - `**devops/README.md`** sıfırdan yazıldı: 4-yollu deployment karar matrisi
   (Docker / SystemD / Windows / K8s), Spring profile vs ENV variable ayrımı,
   sertifika yerleşim konvansiyonu, ortak env variable tablosu.
 - **XAdES `<SigningTime>` timezone parametrik hâle getirildi**
@@ -894,7 +941,7 @@ servislerinde `instanceof` kontrolü yok.
 - `**SigningMaterialContentSigner`** — BouncyCastle `ContentSigner`
 arabirimini backend-agnostic olarak gerçekler; CAdES için CMS
 imza yolunda kullanılır.
-- `**X509ExtensionInspector**` — sertifika seçimi için Key Usage,
+- `**X509ExtensionInspector`** — sertifika seçimi için Key Usage,
 Extended Key Usage, Subject Alt Name, OID listesi ve policies
 inspect eder; HSM sertifika keşfinde tek-eşleşme garantisini
 yapısal olarak doğrular.
@@ -977,7 +1024,7 @@ altındaki 8 yeni test: `IaikContentSignerTest`, `IaikPkcs11ModuleContractTest`,
 #### 📤 Signed-artifact export sistemi
 
 - `**SignedArtifactExporter`** (`testsupport/SignedArtifactExporter.java`) —
-JUnit 5 extension, `**@ExtendWith(SignedArtifactExporter.class)**` veya
+JUnit 5 extension, `**@ExtendWith(SignedArtifactExporter.class)`** veya
 `@RegisterExtension` ile aktif edilir; her test imzaladığı bytes'ı
 `target/signed-artifacts/<format>/<methodName>__<sanitize(label)>.<ext>`
 yoluna semantic adıyla yazar.
@@ -1019,7 +1066,7 @@ ve manuel `workflow_dispatch` ile çalışır. URL yapısı:
   - `/openapi/` — Swagger UI 5.17.14 standalone bundle + canlı Spring Boot'tan
   çekilmiş `openapi.json` snapshot'ı.
   - `/security/` — OWASP Dependency-Check HTML rapor.
-- `**docs/landing/index.html**` — Framework-free (sadece Tailwind CDN +
+- `**docs/landing/index.html`** — Framework-free (sadece Tailwind CDN +
 Inter/JetBrains Mono fontları); build metadata `envsubst` veya
 Python fallback ile inject edilir. Auditor-friendly: hızlı yükleme,
 WCAG-temiz kontrast, JS framework yok.
@@ -1044,7 +1091,7 @@ açar. Flag'ler kapsamı dakikalardan dakikalara değişen modlara böler:
   - `--skip-e2e`, `--skip-owasp`, `--skip-openapi`, `--no-serve`, `--port`.
   - Landing template injection için `envsubst` (linux) veya
   `python3` (macOS) fallback.
-- `**scripts/generate-cades-fixtures.py**` ve
+- `**scripts/generate-cades-fixtures.py`** ve
 `**scripts/generate-xades-fixture-variants.py**` — Test fixture'larının
 deterministic üretimi; git history'de "neden bu byte" şeffaf kalır.
 CAdES: `sample.txt` UTF-8 Türkçe, `sample.bin` SHA-256 zinciri
@@ -1119,7 +1166,7 @@ graceful kontratı), `utf16-text.txt` (UTF-16 BE + BOM).
 - `**devops/docker/Dockerfile.pkcs11-tests`** — Ubuntu tabanlı,
 `softhsm2`, `opensc`, `libsofthsm2.so` ile birlikte JDK 8 +
 Maven; lokal `docker run` ile SoftHSM2 PKCS#11 testlerini koşturur.
-- `**scripts/run-pkcs11-tests.sh**` — Docker'la SoftHSM2 PKCS#11
+- `**scripts/run-pkcs11-tests.sh`** — Docker'la SoftHSM2 PKCS#11
 test suite'ini lokal makinede çalıştırır; native bağımlılık olmadan
 developer experience'ı korur.
 - `**.github/workflows/integration-tests.yml**` — Yeni workflow,
@@ -1185,7 +1232,7 @@ generator-only fixture'lar (`large-10mb.bin`, `large-50pages.pdf`).
 - **🧪 CAdES + PAdES Fixture Varyasyon Suite'leri Eklendi (8 yeni senaryo)** —
 Mevcut `CAdESSignAndVerifyE2ETest` / `PAdESSignAndVerifyE2ETest` PFX × backend
 matrisleri (20 + 10 senaryo) tek programatik girdi üzerinde koşar; yeni
-`**CAdESBinaryVariationsE2ETest`** ve `**PAdESDocumentVariationsE2ETest**`
+`**CAdESBinaryVariationsE2ETest`** ve `**PAdESDocumentVariationsE2ETest`**
 fixture-içerik çeşitliliğini kapsar. Smart matrix: tek RSA PFX × JCA backend
 (key-tipinden bağımsız → CI yükü minimal).
   - **CAdES fixture'ları** (4, `resources/test-fixtures/cades/`):
@@ -1385,7 +1432,7 @@ Sertifika listeleme yanıtı OID, KeyUsage, ExtendedKeyUsage, Policies,
 SAN bilgileri ile genişletildi; HSM token'larında da çalışır.
 - 🐳 `**devops/docker/Dockerfile`** — Yeni Allure / JaCoCo / IAIK
 bağımlılıklarıyla uyumlu, application-local.properties opt-in.
-- 📦 `**pom.xml**` — IAIK PKCS#11 wrapper + Allure 2.27 + JaCoCo
+- 📦 `**pom.xml`** — IAIK PKCS#11 wrapper + Allure 2.27 + JaCoCo
 0.8.11 + OWASP Dependency-Check 9.2.0 + AspectJ Weaver eklendi;
 Surefire `<argLine>` JaCoCo agent + AspectJ weaver inject edecek
 şekilde güncellendi.
@@ -1499,7 +1546,7 @@ artık bağımlılık değil. `pom.xml`'deki `mvn install:install-file`
 hook'u temizlendi; CI'daki `mvn validate -B` adımı artık hiçbir lokal
 jar yüklemiyor — sadece default Maven validate fazını çalıştırır.
 HSM erişimi tamamen `org.xipki:ipkcs11wrapper` 1.0.9 üzerinden.
-- 🗑️ `**resources/test-documents/EFATURA.xml**` — Yerini
+- 🗑️ `**resources/test-documents/EFATURA.xml`** — Yerini
 `resources/test-fixtures/xades/efatura.xml` aldı. Yeni dizin
 yapısı (`test-fixtures/{xades,pades,cades,wssecurity,negative}/`)
 her formata kendi fixture klasörünü atar; eski tek-belge

--- a/clients/dotnet-client/Clients/CertificateInfoClient.cs
+++ b/clients/dotnet-client/Clients/CertificateInfoClient.cs
@@ -22,4 +22,8 @@ internal sealed class CertificateInfoClient : DssSignerHttpBase, ICertificateInf
     /// <inheritdoc />
     public Task<KeystoreInfo> GetInfoAsync(CancellationToken ct = default)
         => GetJsonAsync<KeystoreInfo>("/api/certificates/info", ct);
+
+    /// <inheritdoc />
+    public Task<CertificateInfo> GetSigningCertificateAsync(CancellationToken ct = default)
+        => GetJsonAsync<CertificateInfo>("/api/certificates/signingCertificate", ct);
 }

--- a/clients/dotnet-client/Clients/XadesSigner.cs
+++ b/clients/dotnet-client/Clients/XadesSigner.cs
@@ -30,14 +30,17 @@ internal sealed class XadesSigner : DssSignerHttpBase, IXadesSigner
             throw new ArgumentException("DocumentType.None gönderilemez; geçerli bir XML belge tipi seçin.", nameof(request));
 
         Logger.LogDebug(
-            "DSS Signer XAdES isteği — boyut: {Boyut} bayt, tip: {Tip}, zip: {Zip}",
-            request.Document.Length, request.DocumentType, request.ZipFile);
+            "DSS Signer XAdES isteği — boyut: {Boyut} bayt, tip: {Tip}, zip: {Zip}, seviye: {Seviye}",
+            request.Document.Length, request.DocumentType, request.ZipFile, request.SignatureLevel);
 
         using var form = new MultipartFormDataContent();
         AddFilePart(form, "document", request.Document, request.FileName, "application/xml");
         AddStringPart(form, "documentType", request.DocumentType.ToString());
         AddStringPart(form, "zipFile", request.ZipFile ? "true" : "false");
         AddStringPart(form, "signatureId", request.SignatureId);
+        // signatureLevel asla null değildir (default XADES_BES); enum sabit ismi
+        // sunucu Java enum'u ile birebir eşleşir (XADES_BES / XADES_A).
+        AddStringPart(form, "signatureLevel", request.SignatureLevel.ToString());
 
         using var response = await PostMultipartBinaryAsync("/v1/xadessign", form, ct).ConfigureAwait(false);
         return await BuildSignResultAsync(response, ct).ConfigureAwait(false);

--- a/clients/dotnet-client/Interfaces/ICertificateInfoClient.cs
+++ b/clients/dotnet-client/Interfaces/ICertificateInfoClient.cs
@@ -18,4 +18,25 @@ public interface ICertificateInfoClient
     /// Yapılandırılmış keystore'un genel bilgisini (tip, yol, slot vb.) döner.
     /// </summary>
     Task<KeystoreInfo> GetInfoAsync(CancellationToken ct = default);
+
+    /// <summary>
+    /// Aktif imza yapılandırmasındaki imzacı sertifikayı, base64 encoded biçimde de
+    /// içerecek şekilde tek-shot olarak döner.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Listing endpoint'inin aksine alias/serial filtrelemesi yapılmaz; sunucu,
+    /// başlangıçta resolve ettiği <c>SigningMaterial</c> singleton'ından doğrudan
+    /// beslenir. Yanıt, manuel XAdES <c>&lt;ds:X509Certificate&gt;</c> elementi için
+    /// kullanılabilen <see cref="CertificateInfo.Base64EncodedCertificate"/> alanını
+    /// içerir; <see cref="CertificateInfo.HasPrivateKey"/> her zaman <c>true</c>'dur
+    /// (HSM yolunda dahi, çünkü key handle token'da yaşar).
+    /// </para>
+    /// <para>
+    /// Server tarafı <c>Cache-Control: private, max-age=3600, immutable</c> header'ı
+    /// döndürür; reverse-proxy / in-memory cache'ler bu çağrıyı 0-RTT lookup ile
+    /// karşılayabilir.
+    /// </para>
+    /// </remarks>
+    Task<CertificateInfo> GetSigningCertificateAsync(CancellationToken ct = default);
 }

--- a/clients/dotnet-client/Interfaces/IXadesSigner.cs
+++ b/clients/dotnet-client/Interfaces/IXadesSigner.cs
@@ -10,19 +10,36 @@ namespace MERSEL.Services.DssSigner.Client.Interfaces;
 public interface IXadesSigner
 {
     /// <summary>
-    /// Bir XML belgesini XAdES (BES) profili ile imzalar.
+    /// Bir XML belgesini XAdES profili ile imzalar. İmza profili
+    /// (<see cref="XadesSignatureLevel.XADES_BES"/> /
+    /// <see cref="XadesSignatureLevel.XADES_A"/>) tamamen
+    /// <see cref="SignXadesRequest.SignatureLevel"/> alanı ile belirlenir;
+    /// <see cref="SignXadesRequest.DocumentType"/> seviye kararına <em>dahil değildir</em>.
     /// e-Fatura, e-Arşiv Raporu, e-İrsaliye, Uygulama Yanıtı, HrXml ve serbest
-    /// XML belgeleri desteklenir; <see cref="SignXadesRequest.DocumentType"/> ile
-    /// imzalama profili seçilir.
+    /// XML belgeleri desteklenir.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <b>Varsayılan davranış</b>: <see cref="SignXadesRequest.SignatureLevel"/>
+    /// alanı set edilmediğinde <see cref="XadesSignatureLevel.XADES_BES"/> uygulanır
+    /// — TSA çağrılmaz, kontör harcanmaz. e-Arşiv Raporu / e-Bilet Raporu gibi
+    /// arşivsel akışlarda <see cref="XadesSignatureLevel.XADES_A"/>'nın talep
+    /// edilmesi <em>çağıran tarafın sorumluluğundadır</em>.
+    /// </para>
+    /// <para>
+    /// <see cref="XadesSignatureLevel.XADES_A"/> istenir ve sunucu tarafında TSA
+    /// yapılandırılmamışsa istek HTTP 503 + <c>TIMESTAMP_ERROR</c> ile reddedilir.
+    /// </para>
+    /// </remarks>
     /// <param name="request">İmza isteği parametreleri.</param>
     /// <param name="ct">İptal belirteci.</param>
     /// <returns>İmzalı XML, ham imza değeri ve yanıt metadata'sı.</returns>
     Task<SignResult> SignAsync(SignXadesRequest request, CancellationToken ct = default);
 
     /// <summary>
-    /// Bir XML belgesini varsayılan ayarlarla (ZipFile=false, SignatureId=null)
-    /// XAdES ile imzalamak için kısa yol overload'ı.
+    /// Bir XML belgesini varsayılan ayarlarla (ZipFile=false, SignatureId=null,
+    /// SignatureLevel=<see cref="XadesSignatureLevel.XADES_BES"/>) XAdES ile
+    /// imzalamak için kısa yol overload'ı.
     /// </summary>
     Task<SignResult> SignAsync(byte[] document, DocumentType documentType, CancellationToken ct = default);
 

--- a/clients/dotnet-client/Models/CertificateInfo.cs
+++ b/clients/dotnet-client/Models/CertificateInfo.cs
@@ -59,4 +59,23 @@ public sealed class CertificateInfo
     /// <summary>Sertifika politikaları (Certificate Policies OIDs).</summary>
     [JsonPropertyName("certificatePolicies")]
     public string? CertificatePolicies { get; set; }
+
+    /// <summary>
+    /// Public key algoritması (örn. <c>RSA</c>, <c>EC</c>).
+    /// PR #20 ile eklendi.
+    /// </summary>
+    [JsonPropertyName("publicKeyAlgorithm")]
+    public string? PublicKeyAlgorithm { get; set; }
+
+    /// <summary>
+    /// Base64 encoded X.509 sertifika (DER kodlamanın base64'lenmiş hali).
+    /// </summary>
+    /// <remarks>
+    /// Yalnızca <c>/api/certificates/signingCertificate</c> endpoint'i bu alanı
+    /// doldurur; <c>/api/certificates/list</c> yanıtında <c>null</c> kalır
+    /// (50+ sertifika içeren HSM'lerde payload'un patlamaması için kasıtlı).
+    /// Manuel XAdES <c>&lt;ds:X509Certificate&gt;</c> elementi doldurmak için kullanılır.
+    /// </remarks>
+    [JsonPropertyName("base64EncodedCertificate")]
+    public string? Base64EncodedCertificate { get; set; }
 }

--- a/clients/dotnet-client/Models/SignXadesRequest.cs
+++ b/clients/dotnet-client/Models/SignXadesRequest.cs
@@ -28,4 +28,21 @@ public sealed class SignXadesRequest
     /// imzalama mantığını etkilemez.
     /// </summary>
     public string FileName { get; set; } = "document.xml";
+
+    /// <summary>
+    /// XAdES imza profili. API kontratı gereği <em>asla null değildir</em>;
+    /// varsayılan <see cref="XadesSignatureLevel.XADES_BES"/>'tir
+    /// (timestamp eklenmez, TSA çağrılmaz, kontör harcanmaz).
+    /// </summary>
+    /// <remarks>
+    /// <see cref="XadesSignatureLevel.XADES_A"/> istenirse arşiv timestamp eklenir;
+    /// sunucu tarafında TSA yapılandırılmamışsa istek 503 / <c>TIMESTAMP_ERROR</c>
+    /// ile reddedilir.
+    /// <para>
+    /// <b>Önemli</b>: <see cref="DocumentType"/> artık seviye kararına dahil
+    /// <em>değildir</em>. Rapor akışında XADES_A istenecekse bu alanın explicit
+    /// olarak set edilmesi gerekir.
+    /// </para>
+    /// </remarks>
+    public XadesSignatureLevel SignatureLevel { get; set; } = XadesSignatureLevel.XADES_BES;
 }

--- a/clients/dotnet-client/Models/XadesSignatureLevel.cs
+++ b/clients/dotnet-client/Models/XadesSignatureLevel.cs
@@ -1,0 +1,60 @@
+using System.Text.Json.Serialization;
+
+namespace MERSEL.Services.DssSigner.Client.Models;
+
+/// <summary>
+/// XAdES imza profili (seviyesi).
+/// </summary>
+/// <remarks>
+/// <para>
+/// <b>Karar Verici Sözleşmesi</b> — İmza seviyesinin tek karar vericisi
+/// request'tir. <see cref="DocumentType"/> (örn. <see cref="DocumentType.EArchiveReport"/>)
+/// seviyenin seçimine artık dahil değildir; sistem belge tipine bakarak
+/// otomatik olarak <see cref="XADES_A"/>'ya yükseltme yapmaz.
+/// </para>
+/// <para>
+/// <b>Varsayılan</b> — API kontratı gereği <see cref="SignXadesRequest.SignatureLevel"/>
+/// alanı <em>null olamaz</em>. Talep oluşturulurken bu alan set edilmezse
+/// <see cref="XADES_BES"/> uygulanır — yani upgrade akışına girilmez ve TSA'ya
+/// tek bir round-trip bile gitmez.
+/// </para>
+/// <para>
+/// <b>Mali Sorumluluk</b> — e-Arşiv Raporu / e-Bilet Raporu gibi 10 yıllık
+/// saklama gerektiren akışlarda <see cref="XADES_A"/>'nın istenmesi
+/// <em>çağıran tarafın sorumluluğundadır</em>. Sistem belge tipine göre
+/// proaktif yükseltme yapmaz; "implicit upgrade" davranışı v0.x serisinde
+/// kaldırılmıştır.
+/// </para>
+/// <para>
+/// <b>DSS Eşlemesi</b>:
+/// <list type="bullet">
+///   <item><c>XADES_BES</c> → <c>SignatureLevel.XAdES_BASELINE_B</c></item>
+///   <item><c>XADES_A</c>   → <c>SignatureLevel.XAdES_BASELINE_LTA</c>
+///         (legacy ETSI TS 101 903 terminolojisindeki XAdES-A profili)</item>
+/// </list>
+/// </para>
+/// </remarks>
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum XadesSignatureLevel
+{
+    /// <summary>
+    /// Baseline-B profili: yalnızca <c>ds:Signature</c> ve <c>xades:SignedProperties</c>.
+    /// Hiçbir TSA çağrısı yapılmaz; kontör harcanmaz. e-Fatura, e-Arşiv faturası,
+    /// irsaliye, uygulama yanıtı, HrXml, e-Adisyon raporu, e-Döviz raporu (iptal hariç)
+    /// vb. timestamp gerektirmeyen tüm akışlar için. <b>API'nin varsayılan değeri.</b>
+    /// </summary>
+    XADES_BES,
+
+    /// <summary>
+    /// Baseline-LTA profili (legacy adıyla XAdES-A): imza + signature timestamp +
+    /// archive timestamp. e-Arşiv Raporu / e-Bilet Raporu gibi arşivsel akışlar için
+    /// uygundur.
+    /// <para>
+    /// <b>Zorunlu önkoşul</b>: Sunucu tarafında TSA host'u yapılandırılmış olmalı
+    /// (örn. <c>TS_SERVER_HOST</c> property). Aksi halde imza akışı fail-fast olarak
+    /// <c>TIMESTAMP_ERROR</c> ile reddedilir — <see cref="XADES_BES"/> seviyesinde
+    /// sessiz fallback yapılmaz (silent data corruption pattern'inden kasıtlı kaçınma).
+    /// </para>
+    /// </summary>
+    XADES_A
+}

--- a/clients/dotnet-client/README.md
+++ b/clients/dotnet-client/README.md
@@ -70,6 +70,7 @@ public class FaturaImzalama(IDssSignerClient signer)
 {
     public async Task<byte[]> EFaturaImzala(byte[] ublXml, CancellationToken ct = default)
     {
+        // Varsayılan profil XADES_BES — TSA çağrılmaz, kontör harcanmaz.
         var result = await signer.Xades.SignAsync(ublXml, DocumentType.UblDocument, ct);
         // result.SignedDocument → imzalı XML
         // result.SignatureValue → x-signature-value header'ı (Base64)
@@ -77,6 +78,35 @@ public class FaturaImzalama(IDssSignerClient signer)
     }
 }
 ```
+
+#### XAdES İmza Profilini (BES / A) Seçme
+
+İmza profili artık tamamen request alanı ile belirlenir; `DocumentType` seviye kararına dahil değildir.
+e-Arşiv Raporu / e-Bilet Raporu gibi arşivsel akışlarda XAdES-A istemek isterseniz `SignatureLevel`'ı
+explicit set edin:
+
+```csharp
+// 1) Default (BES) — alan set edilmediğinde otomatik XADES_BES uygulanır.
+var bes = await signer.Xades.SignAsync(new SignXadesRequest
+{
+    Document = ublXml,
+    DocumentType = DocumentType.UblDocument
+    // SignatureLevel = XadesSignatureLevel.XADES_BES (default)
+});
+
+// 2) e-Arşiv Raporu için XAdES-A (archive timestamp eklenir).
+//    Sunucu tarafında TSA yapılandırılmamışsa 503 + TIMESTAMP_ERROR alırsınız.
+var rapor = await signer.Xades.SignAsync(new SignXadesRequest
+{
+    Document = earsivRaporXml,
+    DocumentType = DocumentType.EArchiveReport,
+    SignatureLevel = XadesSignatureLevel.XADES_A
+});
+```
+
+> **Mali sorumluluk**: e-Arşiv Raporu / e-Bilet Raporu gibi 10 yıllık saklama gerektiren akışlarda
+> `XADES_A` talebi çağıran tarafın sorumluluğundadır. Sistem belge tipine bakarak otomatik upgrade
+> yapmaz.
 
 ### WS-Security (SOAP zarfı)
 
@@ -145,6 +175,25 @@ foreach (var sert in liste.Certificates)
 var info = await signer.Certificates.GetInfoAsync();
 Console.WriteLine(info.KeystoreType);   // PKCS11 / PFX
 ```
+
+#### İmzacı Sertifikayı Tek-Shot Alma (Manuel XAdES İçin)
+
+Manuel `<ds:X509Certificate>` doldurmak (örn. UBL-TR 2.1 namespace prefix gereksinimi olan
+özel akışlar) için aktif imzacı sertifikayı base64 encoded biçimde tek bir çağrıyla alabilirsiniz.
+Sunucu `Cache-Control: private, max-age=3600, immutable` döndürür; reverse-proxy / in-memory
+cache'ler tekrarlı çağrılarda 0-RTT lookup yapar.
+
+```csharp
+var imzaciSertifika = await signer.Certificates.GetSigningCertificateAsync();
+
+Console.WriteLine($"Alias: {imzaciSertifika.Alias}");
+Console.WriteLine($"Algoritma: {imzaciSertifika.PublicKeyAlgorithm}");     // RSA / EC
+string base64Der = imzaciSertifika.Base64EncodedCertificate!;
+// ds:X509Certificate elementine doğrudan basılabilir.
+```
+
+> **Not**: `Base64EncodedCertificate` alanı yalnızca bu endpoint'te doludur; `ListAsync()`
+> yanıtında `null` kalır (50+ sertifika içeren HSM'lerde payload'un patlamaması için kasıtlı).
 
 ## Hata Yönetimi
 

--- a/src/main/java/io/mersel/dss/signer/api/controllers/XadesController.java
+++ b/src/main/java/io/mersel/dss/signer/api/controllers/XadesController.java
@@ -59,7 +59,11 @@ public class XadesController {
 
     @Operation(
         summary = "XML belgelerini XAdES imzası ile imzalar",
-        description = "e-Fatura, e-Arşiv Raporu, Uygulama Yanıtı, İrsaliye, HrXml ve diğer XML belgelerini destekler"
+        description = "e-Fatura, e-Arşiv Raporu, Uygulama Yanıtı, İrsaliye, HrXml ve diğer XML belgelerini destekler. "
+                + "İmza profili (XADES_BES / XADES_A) tamamen 'signatureLevel' alanı ile belirlenir; "
+                + "documentType seviye kararına dahil değildir. Alan gönderilmezse XADES_BES uygulanır "
+                + "(TSA çağrılmaz, kontör harcanmaz). XADES_A istenirse TSA yapılandırılmamışsa "
+                + "istek TIMESTAMP_ERROR ile reddedilir."
     )
     @RequestMapping(value = "/v1/xadessign", method = RequestMethod.POST, 
         consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
@@ -94,7 +98,7 @@ public class XadesController {
                     dto.getSignatureId(),
                     zipped,
                     signingMaterial,
-                    dto.isDisableTimeStamp()
+                    dto.getSignatureLevel()
                 );
             }
 

--- a/src/main/java/io/mersel/dss/signer/api/controllers/XadesController.java
+++ b/src/main/java/io/mersel/dss/signer/api/controllers/XadesController.java
@@ -93,7 +93,8 @@ public class XadesController {
                     dto.getDocumentType(),
                     dto.getSignatureId(),
                     zipped,
-                    signingMaterial
+                    signingMaterial,
+                    dto.isDisableTimeStamp()
                 );
             }
 

--- a/src/main/java/io/mersel/dss/signer/api/dtos/SignXadesDto.java
+++ b/src/main/java/io/mersel/dss/signer/api/dtos/SignXadesDto.java
@@ -6,13 +6,28 @@ import org.springframework.web.multipart.MultipartFile;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 
 public class SignXadesDto {
     private MultipartFile Document;
     private String SignatureId;
     private DocumentType DocumentType;
     private Boolean ZipFile;
-    private boolean DisableTimeStamp;
+
+    /**
+     * XAdES imza profili (seviyesi). API kontratı gereği bu alan
+     * <strong>asla null değildir</strong>; gönderilmediği takdirde varsayılan
+     * {@link XadesSignatureLevel#XADES_BES} uygulanır. Bu durumda archive timestamp
+     * eklenmez, TSA çağrılmaz, kontör harcanmaz.
+     *
+     * <p>{@link XadesSignatureLevel#XADES_A} istenirse arşiv timestamp eklenir;
+     * TSA yapılandırılmamışsa istek 503 / {@code TIMESTAMP_ERROR} ile reddedilir.</p>
+     *
+     * <p><strong>Önemli</strong>: {@code documentType} (örn. EArchiveReport) artık
+     * seviye kararına dahil <em>değildir</em>. Rapor akışında XADES_A istenecekse
+     * bu alanın explicit olarak gönderilmesi gerekir.</p>
+     */
+    private XadesSignatureLevel SignatureLevel = XadesSignatureLevel.XADES_BES;
 
     public String getSignatureId() {
         return SignatureId;
@@ -49,11 +64,32 @@ public class SignXadesDto {
         ZipFile = zipFile;
     }
 
-    public boolean isDisableTimeStamp() {
-        return DisableTimeStamp;
+    /**
+     * Daima non-null bir {@link XadesSignatureLevel} döner. Non-null kontratı
+     * iki katmanda korunur: (a) field initializer ctor sonrası başlangıç
+     * değerini garantiler, (b) setter null gelirse {@link XadesSignatureLevel#XADES_BES}
+     * fallback uygular. Dolayısıyla getter savunmacı bir null check yapmak
+     * zorunda değildir.
+     */
+    public XadesSignatureLevel getSignatureLevel() {
+        return SignatureLevel;
     }
 
-    public void setDisableTimeStamp(boolean disableTimeStamp) {
-        this.DisableTimeStamp = disableTimeStamp;
+    /**
+     * Setter; {@code null} geçirildiğinde alan {@link XadesSignatureLevel#XADES_BES}'e
+     * düşürülür. Bu, multipart form binding senaryolarında alan boş gelse bile
+     * "asla null" kontratının korunmasını garanti eder.
+     */
+    @Schema(
+        enumAsRef = true,
+        description = "XAdES imza profili. Boş bırakılırsa XADES_BES davranışı uygulanır "
+                + "(timestamp eklenmez, TSA çağrılmaz). XADES_A istenirse arşiv timestamp "
+                + "eklenir; TSA yapılandırılmamışsa istek TIMESTAMP_ERROR ile reddedilir. "
+                + "documentType seviye kararına dahil değildir — karar tamamen bu alana bağlıdır.",
+        example = "XADES_BES",
+        defaultValue = "XADES_BES"
+    )
+    public void setSignatureLevel(XadesSignatureLevel signatureLevel) {
+        SignatureLevel = signatureLevel != null ? signatureLevel : XadesSignatureLevel.XADES_BES;
     }
 }

--- a/src/main/java/io/mersel/dss/signer/api/dtos/SignXadesDto.java
+++ b/src/main/java/io/mersel/dss/signer/api/dtos/SignXadesDto.java
@@ -12,6 +12,7 @@ public class SignXadesDto {
     private String SignatureId;
     private DocumentType DocumentType;
     private Boolean ZipFile;
+    private boolean DisableTimeStamp;
 
     public String getSignatureId() {
         return SignatureId;
@@ -46,5 +47,13 @@ public class SignXadesDto {
 
     public void setZipFile(Boolean zipFile) {
         ZipFile = zipFile;
+    }
+
+    public boolean isDisableTimeStamp() {
+        return DisableTimeStamp;
+    }
+
+    public void setDisableTimeStamp(boolean disableTimeStamp) {
+        this.DisableTimeStamp = disableTimeStamp;
     }
 }

--- a/src/main/java/io/mersel/dss/signer/api/models/enums/XadesSignatureLevel.java
+++ b/src/main/java/io/mersel/dss/signer/api/models/enums/XadesSignatureLevel.java
@@ -1,0 +1,57 @@
+package io.mersel.dss.signer.api.models.enums;
+
+/**
+ * XAdES imza profili (seviyesi).
+ *
+ * <h3>Karar Verici Sözleşmesi</h3>
+ * <p>İmza seviyesinin tek karar vericisi <em>request</em>'tir. {@code documentType}
+ * (örn. {@link DocumentType#EArchiveReport}) seviyenin seçimine artık dahil değildir;
+ * sistem belge tipine bakarak otomatik olarak XADES_A'ya yükseltme yapmaz.</p>
+ *
+ * <h3>Profiller</h3>
+ * <ul>
+ *   <li>{@link #XADES_BES} — Yalnızca imza, TSA çağrılmaz.</li>
+ *   <li>{@link #XADES_A}   — Archive timestamp ile genişletilmiş profil; TSA gerekir.</li>
+ * </ul>
+ *
+ * <h3>Varsayılan</h3>
+ * <p>API kontratı gereği bu alan <strong>null olamaz</strong>. Request'te alan
+ * gönderilmezse {@link #XADES_BES} değeri uygulanır — yani upgrade akışına
+ * girilmez ve TSA'ya tek bir RTT bile gitmez.</p>
+ *
+ * <h3>Mali Sorumluluk</h3>
+ * <p>e-Arşiv Raporu / e-Bilet Raporu gibi 10 yıllık saklama gerektiren akışlarda
+ * {@code XADES_A}'nın istenmesi <em>çağıran tarafın sorumluluğundadır</em>.
+ * Sistem belge tipine göre proaktif yükseltme yapmaz; "implicit upgrade" davranışı
+ * v0.x serisinde kaldırılmıştır.</p>
+ *
+ * <h3>DSS Eşlemesi</h3>
+ * <ul>
+ *   <li>{@code XADES_BES} → {@code eu.europa.esig.dss.enumerations.SignatureLevel.XAdES_BASELINE_B}</li>
+ *   <li>{@code XADES_A}   → {@code eu.europa.esig.dss.enumerations.SignatureLevel.XAdES_BASELINE_LTA}
+ *       (legacy ETSI TS 101 903 terminolojisindeki XAdES-A profili)</li>
+ * </ul>
+ */
+public enum XadesSignatureLevel {
+
+    /**
+     * Baseline-B profili: yalnızca <code>ds:Signature</code> ve <code>xades:SignedProperties</code>.
+     * Hiçbir TSA çağrısı yapılmaz; kontör harcanmaz.
+     * e-Fatura, e-Arşiv faturası, irsaliye, uygulama yanıtı, HrXml, e-Adisyon raporu,
+     * e-Döviz raporu (iptal hariç) vb. timestamp gerektirmeyen tüm akışlar için.
+     */
+    XADES_BES,
+
+    /**
+     * Baseline-LTA profili (legacy adıyla XAdES-A): imza + signature timestamp +
+     * archive timestamp. e-Arşiv Raporu / e-Bilet Raporu gibi arşivsel akışlar için
+     * uygundur.
+     *
+     * <p><strong>Zorunlu önkoşul</strong>: TSA host'u yapılandırılmış
+     * olmalı (örn. {@code TS_SERVER_HOST} property). Aksi halde imza akışı
+     * fail-fast olarak {@code TIMESTAMP_ERROR} ile reddedilir — XADES_BES
+     * seviyesinde sessiz fallback yapılmaz (silent data corruption pattern'inden
+     * kasıtlı kaçınma).</p>
+     */
+    XADES_A
+}

--- a/src/main/java/io/mersel/dss/signer/api/services/signature/xades/XAdESLevelUpgradeService.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/signature/xades/XAdESLevelUpgradeService.java
@@ -7,7 +7,7 @@ import eu.europa.esig.dss.xades.XAdESSignatureParameters;
 import eu.europa.esig.dss.xades.XAdESTimestampParameters;
 import eu.europa.esig.dss.xades.signature.XAdESLevelA;
 import io.mersel.dss.signer.api.exceptions.TimestampException;
-import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.timestamp.TimestampConfigurationService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,24 +17,43 @@ import javax.xml.crypto.dsig.CanonicalizationMethod;
 
 /**
  * XAdES imza seviyelerini yükselten servis.
- * e-Arşiv Raporları ve e-Bilet Raporları için XAdES-B'den XAdES-A'ya yükseltme yapar.
  *
- * <h3>Fail-fast sözleşmesi</h3>
- * <p>e-Arşiv ve e-Bilet raporları GİB tarafına XAdES-A (archival) seviyesinde
- * gönderilmek <em>zorundadır</em> — TSA imzası ve archive timestamp olmadan
- * üretilen rapor 10 yıllık saklama gereğine uymaz ve karşı tarafça reddedilir.
- * Bu yüzden:</p>
+ * <h3>Karar Verici Sözleşmesi</h3>
+ * <p>İmza seviyesinin <em>tek</em> karar vericisi request'te gelen
+ * {@link XadesSignatureLevel} alanıdır. Belge tipi (örn. {@code EArchiveReport},
+ * {@code EBiletReport}) seviyenin seçimine dahil değildir; sistem belge tipine
+ * bakarak otomatik olarak XADES_A'ya yükseltme yapmaz. v0.x'te kalan
+ * "rapor tipinde implicit upgrade" davranışı kaldırılmıştır.</p>
+ *
+ * <h3>Davranış Tablosu</h3>
+ * <table>
+ *   <tr><th>requestedLevel</th><th>Davranış</th></tr>
+ *   <tr><td>{@link XadesSignatureLevel#XADES_BES}</td><td>Orijinal belge döner. TSA'ya çağrı yok.</td></tr>
+ *   <tr><td>{@link XadesSignatureLevel#XADES_A}</td><td>Archive timestamp eklenir.
+ *       TSA yapılandırılmamışsa {@link TimestampException} fırlatılır (fail-fast).</td></tr>
+ * </table>
+ *
+ * <h3>Non-null Kontratı</h3>
+ * <p>{@code requestedLevel} parametresi <strong>asla null olamaz</strong>. DTO
+ * katmanı (getter) zaten null'u {@code XADES_BES}'e düşürür; bu servise null
+ * gelmesi {@link NullPointerException} ile programlama hatası olarak yansır.</p>
+ *
+ * <h3>Fail-fast sözleşmesi (XADES_A iken)</h3>
  * <ul>
  *   <li>Timestamp sunucusu yapılandırılmamışsa (TS_SERVER_HOST boş)
  *       sessiz fallback yerine {@link TimestampException} fırlatılır
  *       — caller HTTP 503 + {@code TIMESTAMP_ERROR} alır.</li>
- *   <li>XAdES-A yükseltmesi sırasında oluşan herhangi bir hata da
- *       {@link TimestampException} olarak yukarı bubble edilir; XAdES-B
- *       seviyesinde "yarım imzalı" rapor üretilmez.</li>
+ *   <li>XADES_A yükseltmesi sırasında oluşan herhangi bir hata da
+ *       {@link TimestampException} olarak yukarı bubble edilir; XADES_BES
+ *       seviyesinde "yarım imzalı" belge üretilmez (silent data corruption
+ *       pattern'inden kasıtlı kaçınma).</li>
  * </ul>
- * <p>Önceki davranışta hata durumlarında WARN loglayıp orijinal XAdES-B belgesi
- * döndürülüyordu; bu sessizce uyumsuz rapor üretiyordu (silent data corruption
- * pattern). Bu sınıf artık fail-fast garantisi verir.</p>
+ *
+ * <h3>Mali Sorumluluk Notu</h3>
+ * <p>e-Arşiv Raporu / e-Bilet Raporu gibi 10 yıllık saklama gerektiren akışlarda
+ * XADES_A profilinin talep edilmesi çağıran tarafın sorumluluğundadır. Sistem
+ * documentType'a göre proaktif yükseltme yapmadığı için, eski client'ların
+ * doğrudan {@code XadesSignatureLevel.XADES_A} göndermesi gerekir.</p>
  */
 @Service
 public class XAdESLevelUpgradeService {
@@ -51,38 +70,34 @@ public class XAdESLevelUpgradeService {
     }
 
     /**
-     * Belge tipine göre imza seviyesini yükseltir.
-     * e-Arşiv Raporları ve e-Bilet Raporları için XAdES-A yükseltmesi yapılır.
+     * Request'te gelen imza profiline göre belgeyi gerekirse XADES_A seviyesine yükseltir.
      *
-     * @param signedDocument İmzalanmış belge
-     * @param documentType Belge tipi
+     * @param signedDocument İmzalanmış belge (baseline XAdES-B çıktısı)
      * @param baseParameters Temel imza parametreleri
-     * @return Seviyesi yükseltilmiş belge (XAdES-A); upgrade gerekmeyen belge tipleri için orijinal
-     * @throws TimestampException XAdES-A gerektiren belge tipi için timestamp sunucusu
-     *         yapılandırılmamışsa veya yükseltme işlemi başarısız olursa
+     * @param requestedLevel İstenen XAdES profili. {@link XadesSignatureLevel#XADES_BES}
+     *                       ise orijinal belge döner; {@link XadesSignatureLevel#XADES_A}
+     *                       ise archive timestamp eklenir. <strong>null geçilemez</strong>.
+     * @return Seviyesi yükseltilmiş belge ({@code XADES_A} için) veya orijinal belge
+     * @throws TimestampException {@code XADES_A} istenmiş ve TSA yapılandırılmamışsa veya
+     *         yükseltme işlemi başarısız olursa
      */
     public DSSDocument upgradeIfNeeded(DSSDocument signedDocument,
-                                      DocumentType documentType,
-                                      XAdESSignatureParameters baseParameters,boolean disableTimestamp) {
-        if (documentType != DocumentType.EArchiveReport && documentType != DocumentType.EBiletReport) {
-            return signedDocument;
-        }
-
-        if(disableTimestamp){
+                                      XAdESSignatureParameters baseParameters,
+                                      XadesSignatureLevel requestedLevel) {
+        if (requestedLevel != XadesSignatureLevel.XADES_A) {
+            // XADES_BES — TSA'ya tek bir RTT bile gitmesin.
             return signedDocument;
         }
 
         if (!timestampService.isAvailable()) {
-            String message = String.format(
-                    "%s için XAdES-A yükseltmesi zorunludur ancak timestamp sunucusu yapılandırılmamış. "
-                            + "TS_SERVER_HOST property'sini ayarlayın.",
-                    documentType);
+            String message = "XADES_A profili istendi ancak timestamp sunucusu yapılandırılmamış. "
+                    + "TS_SERVER_HOST property'sini ayarlayın.";
             LOGGER.error(message);
             throw new TimestampException(message);
         }
 
         try {
-            LOGGER.info("{} için XAdES-A seviyesine yükseltiliyor...", documentType);
+            LOGGER.info("XADES_A seviyesine yükseltiliyor (request bazlı)...");
 
             XAdESTimestampParameters tsParams = new XAdESTimestampParameters();
             tsParams.setCanonicalizationMethod(CanonicalizationMethod.INCLUSIVE_WITH_COMMENTS);
@@ -98,7 +113,7 @@ public class XAdESLevelUpgradeService {
 
             DSSDocument upgradedDocument = levelA.extendSignatures(signedDocument, baseParameters);
 
-            LOGGER.info("{} başarıyla XAdES-A seviyesine yükseltildi", documentType);
+            LOGGER.info("Belge başarıyla XADES_A seviyesine yükseltildi");
             return upgradedDocument;
 
         } catch (TimestampException ex) {
@@ -106,13 +121,10 @@ public class XAdESLevelUpgradeService {
             // tekrar sarmalamadan bubble et ki orijinal hata kodu/mesajı korunsun.
             throw ex;
         } catch (Exception ex) {
-            String message = String.format(
-                    "%s için XAdES-A yükseltmesi başarısız. Belge XAdES-B seviyesinde bırakılamaz; "
-                            + "imza işlemi reddediliyor.",
-                    documentType);
+            String message = "XADES_A yükseltmesi başarısız. Belge XADES_BES seviyesinde "
+                    + "bırakılamaz; imza işlemi reddediliyor.";
             LOGGER.error(message, ex);
             throw new TimestampException(message, ex);
         }
     }
 }
-

--- a/src/main/java/io/mersel/dss/signer/api/services/signature/xades/XAdESLevelUpgradeService.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/signature/xades/XAdESLevelUpgradeService.java
@@ -63,8 +63,12 @@ public class XAdESLevelUpgradeService {
      */
     public DSSDocument upgradeIfNeeded(DSSDocument signedDocument,
                                       DocumentType documentType,
-                                      XAdESSignatureParameters baseParameters) {
+                                      XAdESSignatureParameters baseParameters,boolean disableTimestamp) {
         if (documentType != DocumentType.EArchiveReport && documentType != DocumentType.EBiletReport) {
+            return signedDocument;
+        }
+
+        if(disableTimestamp){
             return signedDocument;
         }
 

--- a/src/main/java/io/mersel/dss/signer/api/services/signature/xades/XAdESSignatureService.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/signature/xades/XAdESSignatureService.java
@@ -99,7 +99,7 @@ public class XAdESSignatureService {
             DocumentType documentType,
             String signatureId,
             boolean zipped,
-            SigningMaterial material) {
+            SigningMaterial material,boolean disableTimestamp) {
         try {
             // 1. XML byte'larını çıkar
             byte[] xmlBytes = extractXmlBytes(xmlInputStream, zipped);
@@ -209,7 +209,7 @@ public class XAdESSignatureService {
 
             // e-Arşiv Raporu ise XAdES-A seviyesine yükselt
             signedDocument = levelUpgradeService.upgradeIfNeeded(
-                    signedDocument, documentType, parameters);
+                    signedDocument, documentType, parameters,false);
 
             // Signature ID'yi yakala (cache cleanup için)
             SignedDocumentValidator tempValidator = SignedDocumentValidator.fromDocument(signedDocument);

--- a/src/main/java/io/mersel/dss/signer/api/services/signature/xades/XAdESSignatureService.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/signature/xades/XAdESSignatureService.java
@@ -29,6 +29,7 @@ import io.mersel.dss.signer.api.exceptions.SignatureException;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningMaterial;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.crypto.CryptoSignerService;
 
 /**
@@ -88,18 +89,28 @@ public class XAdESSignatureService {
     /**
      * XML belgesini XAdES imzası ile imzalar.
      *
-     * @param xmlInputStream XML belgesi içeren input stream
-     * @param documentType   Belge tipi (e-Fatura, e-Arşiv vb.)
-     * @param signatureId    İsteğe bağlı imza tanımlayıcısı
-     * @param zipped         Belgenin ZIP formatında olup olmadığı
-     * @param material       İmzalama sertifikası ve private key içeren materyal
+     * @param xmlInputStream  XML belgesi içeren input stream
+     * @param documentType    Belge tipi (e-Fatura, e-Arşiv vb.). İmzanın yerleşim
+     *                        kuralları, UBL extension hazırlığı ve OCSP cache cleanup
+     *                        davranışı bu alana göre belirlenir; ancak XAdES <em>seviyesi</em>
+     *                        artık bu alandan bağımsızdır.
+     * @param signatureId     İsteğe bağlı imza tanımlayıcısı
+     * @param zipped          Belgenin ZIP formatında olup olmadığı
+     * @param material        İmzalama sertifikası ve private key içeren materyal
+     * @param signatureLevel  İstenen XAdES profili. {@link XadesSignatureLevel#XADES_BES}
+     *                        ise yalnızca baseline imza üretilir; TSA çağrılmaz.
+     *                        {@link XadesSignatureLevel#XADES_A} ise archive timestamp eklenir;
+     *                        TSA yapılandırılmamışsa istek fail-fast olarak reddedilir.
+     *                        <strong>null geçilemez</strong>; controller katmanı DTO getter'ı
+     *                        üzerinden XADES_BES fallback'i garantiler.
      * @return İmzalanmış belge ve imza değeri içeren yanıt
      */
     public SignResponse signXml(InputStream xmlInputStream,
             DocumentType documentType,
             String signatureId,
             boolean zipped,
-            SigningMaterial material,boolean disableTimestamp) {
+            SigningMaterial material,
+            XadesSignatureLevel signatureLevel) {
         try {
             // 1. XML byte'larını çıkar
             byte[] xmlBytes = extractXmlBytes(xmlInputStream, zipped);
@@ -132,7 +143,7 @@ public class XAdESSignatureService {
 
             // 7. İmzayı oluştur
             SignResponse response = createSignature(document, dssDocument, parameters,
-                    documentType, material);
+                    documentType, material, signatureLevel);
 
             // 8. Gerekirse ZIP'le
             if (zipped) {
@@ -160,7 +171,8 @@ public class XAdESSignatureService {
             DSSDocument dssDocument,
             XAdESSignatureParameters parameters,
             DocumentType documentType,
-            SigningMaterial material) throws Exception {
+            SigningMaterial material,
+            XadesSignatureLevel signatureLevel) throws Exception {
 
         // OCSP cache cleanup için signature ID'yi takip et
         String actualSignatureId = null;
@@ -207,9 +219,11 @@ public class XAdESSignatureService {
             DSSDocument signedDocument = xadesService.signDocument(
                     dssDocument, parameters, signatureValue);
 
-            // e-Arşiv Raporu ise XAdES-A seviyesine yükselt
+            // İmza seviyesi tamamen request ile gelen 'signatureLevel' alanına bağlıdır.
+            // documentType artık seviye kararına dahil değildir; rapor tipi olsa bile
+            // XADES_A açıkça istenmediği sürece archive timestamp eklenmez.
             signedDocument = levelUpgradeService.upgradeIfNeeded(
-                    signedDocument, documentType, parameters,false);
+                    signedDocument, parameters, signatureLevel);
 
             // Signature ID'yi yakala (cache cleanup için)
             SignedDocumentValidator tempValidator = SignedDocumentValidator.fromDocument(signedDocument);
@@ -246,10 +260,12 @@ public class XAdESSignatureService {
                 // 1. Bu imzaya özel cache'i temizle (her imza için)
                 XAdESLevelC.cleanupOcspCache(actualSignatureId);
 
-                // 2. Eski genel cache'leri temizle (sadece e-Arşiv Raporu/XAdES-A upgrade
-                // yapıldıysa)
-                // Çünkü XAdES-A upgrade sırasında çok fazla OCSP/CRL cache'i oluşur
-                if (documentType == DocumentType.EArchiveReport || documentType == DocumentType.EBiletReport) {
+                // 2. Eski genel cache'leri temizle (sadece XADES_A upgrade yapıldıysa)
+                // Çünkü XADES_A upgrade sırasında çok fazla OCSP/CRL cache'i oluşur.
+                // documentType ile koşullamak yerine, gerçekten XADES_A istenmiş mi
+                // olduğuna bakıyoruz: rapor tipinde olup XADES_BES seçilen istek
+                // hiç ek OCSP/CRL üretmez, gereksiz cleanup tetiklenmesin.
+                if (signatureLevel == XadesSignatureLevel.XADES_A) {
                     XAdESLevelC.cleanupOldCaches(5 * 60 * 1000L);
                 }
             }

--- a/src/test/java/io/mersel/dss/signer/api/controllers/XadesControllerTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/controllers/XadesControllerTest.java
@@ -3,6 +3,7 @@ package io.mersel.dss.signer.api.controllers;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningMaterial;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.signature.wssecurity.WsSecuritySignatureService;
 import io.mersel.dss.signer.api.services.signature.xades.XAdESSignatureService;
 import io.qameta.allure.Epic;
@@ -74,7 +75,8 @@ class XadesControllerTest {
             eq(DocumentType.UblDocument),
             isNull(),
             eq(false),
-            eq(signingMaterial),false
+            eq(signingMaterial),
+            eq(XadesSignatureLevel.XADES_BES)
         )).thenReturn(mockResponse);
 
         // When
@@ -134,7 +136,9 @@ class XadesControllerTest {
 
     @Test
     void testSignXadesWithEBiletReportSuccess() throws Exception {
-        // Given
+        // Given: rapor tipi gönderilse bile signatureLevel set edilmediği için
+        // DTO kontratı XADES_BES default uygular. documentType artık seviye
+        // kararına dahil değildir.
         String xmlContent = "<?xml version=\"1.0\"?><biletRapor><baslik/></biletRapor>";
         MockMultipartFile file = new MockMultipartFile(
             "document",
@@ -153,7 +157,8 @@ class XadesControllerTest {
             eq(DocumentType.EBiletReport),
             isNull(),
             eq(false),
-            eq(signingMaterial),false
+            eq(signingMaterial),
+            eq(XadesSignatureLevel.XADES_BES)
         )).thenReturn(mockResponse);
 
         // When
@@ -194,7 +199,8 @@ class XadesControllerTest {
             any(DocumentType.class),
             any(),
             anyBoolean(),
-            any(),false
+            any(),
+            any(XadesSignatureLevel.class)
         )).thenReturn(mockResponse);
 
         // When
@@ -206,14 +212,155 @@ class XadesControllerTest {
 
         controller.signXades(dto);
 
-        // Then
+        // Then: signatureLevel set edilmediği için DTO default XADES_BES forward eder.
         verify(xadesSignatureService).signXml(
             any(InputStream.class),
             eq(DocumentType.EBiletReport),
             isNull(),
             eq(false),
-            eq(signingMaterial),false
+            eq(signingMaterial),
+            eq(XadesSignatureLevel.XADES_BES)
         );
     }
-}
 
+    @Test
+    void testSignXadesForwardsXADES_AWhenExplicitlyRequested() throws Exception {
+        // Given: rapor tipi + signatureLevel=XADES_A; service'e enum doğru forward edilmeli.
+        String xmlContent = "<?xml version=\"1.0\"?><earsivRapor/>";
+        MockMultipartFile file = new MockMultipartFile(
+            "document",
+            "earsiv-rapor.xml",
+            "text/xml",
+            xmlContent.getBytes()
+        );
+
+        SignResponse mockResponse = new SignResponse(
+            xmlContent.getBytes(),
+            "sig-xades-a"
+        );
+
+        when(xadesSignatureService.signXml(
+            any(InputStream.class),
+            any(DocumentType.class),
+            any(),
+            anyBoolean(),
+            any(),
+            any(XadesSignatureLevel.class)
+        )).thenReturn(mockResponse);
+
+        io.mersel.dss.signer.api.dtos.SignXadesDto dto =
+            new io.mersel.dss.signer.api.dtos.SignXadesDto();
+        dto.setDocument(file);
+        dto.setDocumentType(DocumentType.EArchiveReport);
+        dto.setZipFile(false);
+        dto.setSignatureLevel(XadesSignatureLevel.XADES_A);
+
+        // When
+        ResponseEntity<?> response = controller.signXades(dto);
+
+        // Then
+        assertNotNull(response);
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        verify(xadesSignatureService).signXml(
+            any(InputStream.class),
+            eq(DocumentType.EArchiveReport),
+            isNull(),
+            eq(false),
+            eq(signingMaterial),
+            eq(XadesSignatureLevel.XADES_A)
+        );
+    }
+
+    @Test
+    void testSignXadesForwardsXADES_BESWhenExplicitlyRequested() throws Exception {
+        // Given: rapor tipinde explicit XADES_BES; documentType artık karar verici değildir.
+        String xmlContent = "<?xml version=\"1.0\"?><dovizRapor/>";
+        MockMultipartFile file = new MockMultipartFile(
+            "document",
+            "edoviz-rapor.xml",
+            "text/xml",
+            xmlContent.getBytes()
+        );
+
+        SignResponse mockResponse = new SignResponse(
+            xmlContent.getBytes(),
+            "sig-bes-rapor"
+        );
+
+        when(xadesSignatureService.signXml(
+            any(InputStream.class),
+            any(DocumentType.class),
+            any(),
+            anyBoolean(),
+            any(),
+            any(XadesSignatureLevel.class)
+        )).thenReturn(mockResponse);
+
+        io.mersel.dss.signer.api.dtos.SignXadesDto dto =
+            new io.mersel.dss.signer.api.dtos.SignXadesDto();
+        dto.setDocument(file);
+        dto.setDocumentType(DocumentType.EBiletReport);
+        dto.setZipFile(false);
+        dto.setSignatureLevel(XadesSignatureLevel.XADES_BES);
+
+        // When
+        controller.signXades(dto);
+
+        // Then: rapor tipi olsa bile BES tercih edildiği için enum BES olarak iletilir.
+        verify(xadesSignatureService).signXml(
+            any(InputStream.class),
+            eq(DocumentType.EBiletReport),
+            isNull(),
+            eq(false),
+            eq(signingMaterial),
+            eq(XadesSignatureLevel.XADES_BES)
+        );
+    }
+
+    @Test
+    void testSignXadesSignatureLevelDefaultsToXADES_BESWhenOmitted() throws Exception {
+        // Given: signatureLevel set edilmedi → DTO non-null kontratı gereği XADES_BES forward edilmeli.
+        String xmlContent = "<?xml version=\"1.0\"?><invoice/>";
+        MockMultipartFile file = new MockMultipartFile(
+            "document",
+            "invoice.xml",
+            "text/xml",
+            xmlContent.getBytes()
+        );
+
+        SignResponse mockResponse = new SignResponse(
+            xmlContent.getBytes(),
+            "sig-default"
+        );
+
+        when(xadesSignatureService.signXml(
+            any(InputStream.class),
+            any(DocumentType.class),
+            any(),
+            anyBoolean(),
+            any(),
+            any(XadesSignatureLevel.class)
+        )).thenReturn(mockResponse);
+
+        io.mersel.dss.signer.api.dtos.SignXadesDto dto =
+            new io.mersel.dss.signer.api.dtos.SignXadesDto();
+        dto.setDocument(file);
+        dto.setDocumentType(DocumentType.UblDocument);
+        dto.setZipFile(false);
+        // signatureLevel set edilmedi.
+
+        // When
+        controller.signXades(dto);
+
+        // Then
+        verify(xadesSignatureService).signXml(
+            any(InputStream.class),
+            eq(DocumentType.UblDocument),
+            isNull(),
+            eq(false),
+            eq(signingMaterial),
+            eq(XadesSignatureLevel.XADES_BES)
+        );
+    }
+
+}

--- a/src/test/java/io/mersel/dss/signer/api/controllers/XadesControllerTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/controllers/XadesControllerTest.java
@@ -74,7 +74,7 @@ class XadesControllerTest {
             eq(DocumentType.UblDocument),
             isNull(),
             eq(false),
-            eq(signingMaterial)
+            eq(signingMaterial),false
         )).thenReturn(mockResponse);
 
         // When
@@ -153,7 +153,7 @@ class XadesControllerTest {
             eq(DocumentType.EBiletReport),
             isNull(),
             eq(false),
-            eq(signingMaterial)
+            eq(signingMaterial),false
         )).thenReturn(mockResponse);
 
         // When
@@ -194,7 +194,7 @@ class XadesControllerTest {
             any(DocumentType.class),
             any(),
             anyBoolean(),
-            any()
+            any(),false
         )).thenReturn(mockResponse);
 
         // When
@@ -212,7 +212,7 @@ class XadesControllerTest {
             eq(DocumentType.EBiletReport),
             isNull(),
             eq(false),
-            eq(signingMaterial)
+            eq(signingMaterial),false
         );
     }
 }

--- a/src/test/java/io/mersel/dss/signer/api/dtos/SignXadesDtoTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/dtos/SignXadesDtoTest.java
@@ -1,0 +1,64 @@
+package io.mersel.dss.signer.api.dtos;
+
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
+import io.qameta.allure.Epic;
+import io.qameta.allure.Feature;
+import io.qameta.allure.Severity;
+import io.qameta.allure.SeverityLevel;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * {@link SignXadesDto} DTO katmanı kontrat testleri.
+ *
+ * <p>Buradaki testler controller veya service'i ilgilendirmez; doğrudan DTO'nun
+ * "<em>SignatureLevel asla null olamaz</em>" kontratını doğrular. Multipart form
+ * binding, JSON deserialize veya manuel setter çağrıları gibi tüm yollardan
+ * gelen null değerlerin {@link XadesSignatureLevel#XADES_BES} fallback'ine
+ * düşürülmesi gerekir.</p>
+ */
+@Epic("API Contract")
+@Feature("SignXadesDto")
+@Severity(SeverityLevel.NORMAL)
+class SignXadesDtoTest {
+
+    @Test
+    @DisplayName("Default ctor sonrası SignatureLevel non-null ve XADES_BES'tir")
+    void defaultConstructorYieldsXADES_BES() {
+        SignXadesDto dto = new SignXadesDto();
+
+        assertEquals(XadesSignatureLevel.XADES_BES, dto.getSignatureLevel(),
+                "Field initializer XADES_BES atamalı — non-null kontratının ilk garantisi");
+    }
+
+    @Test
+    @DisplayName("Setter'a null geçirildiğinde alan XADES_BES'e düşürülür (multipart binding savunması)")
+    void setterNullFallsBackToXADES_BES() {
+        SignXadesDto dto = new SignXadesDto();
+        dto.setSignatureLevel(null);
+
+        assertEquals(XadesSignatureLevel.XADES_BES, dto.getSignatureLevel(),
+                "Setter null-guard kontratı: alan asla null kalmamalı");
+    }
+
+    @Test
+    @DisplayName("Setter'a explicit XADES_A geçirildiğinde değer korunur")
+    void setterExplicitXADES_AIsPreserved() {
+        SignXadesDto dto = new SignXadesDto();
+        dto.setSignatureLevel(XadesSignatureLevel.XADES_A);
+
+        assertEquals(XadesSignatureLevel.XADES_A, dto.getSignatureLevel(),
+                "Setter null-guard fonksiyonel değerleri override etmemeli");
+    }
+
+    @Test
+    @DisplayName("Setter'a explicit XADES_BES geçirildiğinde değer korunur")
+    void setterExplicitXADES_BESIsPreserved() {
+        SignXadesDto dto = new SignXadesDto();
+        dto.setSignatureLevel(XadesSignatureLevel.XADES_BES);
+
+        assertEquals(XadesSignatureLevel.XADES_BES, dto.getSignatureLevel());
+    }
+}

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/CertificateLifecycleNegativeE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/CertificateLifecycleNegativeE2ETest.java
@@ -342,7 +342,7 @@ class CertificateLifecycleNegativeE2ETest extends AbstractVerifierE2ETest {
                 DocumentType.UblDocument,
                 "id-" + UUID.randomUUID().toString().replace("-", ""),
                 /*zipped*/ false,
-                material);
+                material,false);
         return signed.getSignedDocument();
     }
 

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/CertificateLifecycleNegativeE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/CertificateLifecycleNegativeE2ETest.java
@@ -6,6 +6,7 @@ import eu.europa.esig.dss.xades.signature.XAdESService;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningMaterial;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.crypto.CryptoSignerService;
 import io.mersel.dss.signer.api.services.crypto.DigestAlgorithmResolverService;
 import io.mersel.dss.signer.api.services.crypto.SignatureAlgorithmResolverService;
@@ -342,7 +343,7 @@ class CertificateLifecycleNegativeE2ETest extends AbstractVerifierE2ETest {
                 DocumentType.UblDocument,
                 "id-" + UUID.randomUUID().toString().replace("-", ""),
                 /*zipped*/ false,
-                material,false);
+                material, XadesSignatureLevel.XADES_BES);
         return signed.getSignedDocument();
     }
 

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESEcdsaP384EfaturaE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESEcdsaP384EfaturaE2ETest.java
@@ -5,6 +5,7 @@ import eu.europa.esig.dss.xades.signature.XAdESService;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningMaterial;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.crypto.CryptoSignerService;
 import io.mersel.dss.signer.api.services.crypto.DigestAlgorithmResolverService;
 import io.mersel.dss.signer.api.services.crypto.SignatureAlgorithmResolverService;
@@ -208,7 +209,7 @@ class XAdESEcdsaP384EfaturaE2ETest extends AbstractVerifierE2ETest {
                 DocumentType.UblDocument,
                 signatureId,
                 /*zipped*/ false,
-                material,false);
+                material, XadesSignatureLevel.XADES_BES);
         long signMs = (System.nanoTime() - signStartNs) / 1_000_000L;
 
         assertNotNull(signed, "signResponse null");

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESEcdsaP384EfaturaE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESEcdsaP384EfaturaE2ETest.java
@@ -208,7 +208,7 @@ class XAdESEcdsaP384EfaturaE2ETest extends AbstractVerifierE2ETest {
                 DocumentType.UblDocument,
                 signatureId,
                 /*zipped*/ false,
-                material);
+                material,false);
         long signMs = (System.nanoTime() - signStartNs) / 1_000_000L;
 
         assertNotNull(signed, "signResponse null");

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESNegativeE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESNegativeE2ETest.java
@@ -5,6 +5,7 @@ import eu.europa.esig.dss.xades.signature.XAdESService;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningMaterial;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.crypto.CryptoSignerService;
 import io.mersel.dss.signer.api.services.crypto.DigestAlgorithmResolverService;
 import io.mersel.dss.signer.api.services.crypto.SignatureAlgorithmResolverService;
@@ -238,7 +239,7 @@ class XAdESNegativeE2ETest extends AbstractVerifierE2ETest {
                 fixture.getDocumentType(),
                 signatureId,
                 /*zipped*/ false,
-                defaultMaterial,false);
+                defaultMaterial, XadesSignatureLevel.XADES_BES);
         assertNotNull(signed, "signResponse null olmamalı");
         byte[] signedBytes = signed.getSignedDocument();
         assertNotNull(signedBytes, "imzalı XML null olmamalı");

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESNegativeE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESNegativeE2ETest.java
@@ -238,7 +238,7 @@ class XAdESNegativeE2ETest extends AbstractVerifierE2ETest {
                 fixture.getDocumentType(),
                 signatureId,
                 /*zipped*/ false,
-                defaultMaterial);
+                defaultMaterial,false);
         assertNotNull(signed, "signResponse null olmamalı");
         byte[] signedBytes = signed.getSignedDocument();
         assertNotNull(signedBytes, "imzalı XML null olmamalı");

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESSignAndVerifyE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESSignAndVerifyE2ETest.java
@@ -195,7 +195,7 @@ class XAdESSignAndVerifyE2ETest extends AbstractVerifierE2ETest {
                 fixture.getDocumentType(),
                 signatureId,
                 /*zipped*/ false,
-                material);
+                material,false);
         long signNanos = System.nanoTime() - signStart;
 
         assertNotNull(signed, "signResponse null olmamalı");
@@ -267,7 +267,7 @@ class XAdESSignAndVerifyE2ETest extends AbstractVerifierE2ETest {
                 DocumentType.OtherXmlDocument,
                 signatureId,
                 /*zipped*/ false,
-                material);
+                material,false);
 
         assertNotNull(signed, "signResponse null olmamalı");
         byte[] signedBytes = signed.getSignedDocument();
@@ -330,7 +330,7 @@ class XAdESSignAndVerifyE2ETest extends AbstractVerifierE2ETest {
                         fixture.getDocumentType(),
                         "id-" + UUID.randomUUID().toString().replace("-", ""),
                         /*zipped*/ false,
-                        material),
+                        material,false),
                 "TSA yapılandırılmamışken EArchiveReport için TimestampException beklenir; "
                         + "silent XAdES-B fallback regresyon vakası");
 

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESSignAndVerifyE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XAdESSignAndVerifyE2ETest.java
@@ -6,6 +6,7 @@ import io.mersel.dss.signer.api.exceptions.TimestampException;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningMaterial;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.crypto.CryptoSignerService;
 import io.mersel.dss.signer.api.services.crypto.DigestAlgorithmResolverService;
 import io.mersel.dss.signer.api.services.crypto.SignatureAlgorithmResolverService;
@@ -195,7 +196,8 @@ class XAdESSignAndVerifyE2ETest extends AbstractVerifierE2ETest {
                 fixture.getDocumentType(),
                 signatureId,
                 /*zipped*/ false,
-                material,false);
+                material,
+                XadesSignatureLevel.XADES_BES);
         long signNanos = System.nanoTime() - signStart;
 
         assertNotNull(signed, "signResponse null olmamalı");
@@ -267,7 +269,8 @@ class XAdESSignAndVerifyE2ETest extends AbstractVerifierE2ETest {
                 DocumentType.OtherXmlDocument,
                 signatureId,
                 /*zipped*/ false,
-                material,false);
+                material,
+                XadesSignatureLevel.XADES_BES);
 
         assertNotNull(signed, "signResponse null olmamalı");
         byte[] signedBytes = signed.getSignedDocument();
@@ -312,8 +315,11 @@ class XAdESSignAndVerifyE2ETest extends AbstractVerifierE2ETest {
      * taşıdığını doğrular.</p>
      */
     @Test
-    @DisplayName("EArchiveReport: TSA yapılandırılmamışken fail-fast TimestampException fırlatır")
-    void earchiveReportFailsFastWhenTsaUnconfigured() {
+    @DisplayName("XADES_A explicit istendiğinde TSA yapılandırılmamışken fail-fast TimestampException fırlatır")
+    void xadesAFailsFastWhenTsaUnconfigured() {
+        // documentType artık seviye kararına dahil değildir; bu test
+        // request'in explicit XADES_A talebinde fail-fast davranışını
+        // (silent XAdES-B fallback'in oluşmadığını) garanti eder.
         XadesDocumentFixture fixture = XadesDocumentFixture.EARSIV_RAPORU;
         byte[] xmlBytes = fixture.readBytes();
         assertTrue(xmlBytes.length > 0, "e-Arşiv Raporu fixture boş olmamalı");
@@ -330,15 +336,15 @@ class XAdESSignAndVerifyE2ETest extends AbstractVerifierE2ETest {
                         fixture.getDocumentType(),
                         "id-" + UUID.randomUUID().toString().replace("-", ""),
                         /*zipped*/ false,
-                        material,false),
-                "TSA yapılandırılmamışken EArchiveReport için TimestampException beklenir; "
+                        material,
+                        XadesSignatureLevel.XADES_A),
+                "Explicit XADES_A istendiğinde TSA yokken TimestampException beklenir; "
                         + "silent XAdES-B fallback regresyon vakası");
 
         assertEquals("TIMESTAMP_ERROR", ex.getErrorCode(),
                 "GlobalExceptionHandler 503 + TIMESTAMP_ERROR envelope için error code'u görmek zorunda");
-        assertTrue(ex.getMessage().contains("EArchiveReport"),
-                "Mesaj hangi belge tipinin upgrade gerektirdiğini söylemeli ki client doğru "
-                        + "endpoint'i / config property'sini hedefleyebilsin: " + ex.getMessage());
+        assertTrue(ex.getMessage().contains("XADES_A"),
+                "Mesaj hangi profilin TSA gerektirdiğini söylemeli: " + ex.getMessage());
         assertTrue(ex.getMessage().contains("TS_SERVER_HOST"),
                 "Mesaj operatöre yapılandırması gereken property adını söylemeli: " + ex.getMessage());
     }

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XadesSoftHsmVerifierE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XadesSoftHsmVerifierE2ETest.java
@@ -224,7 +224,7 @@ class XadesSoftHsmVerifierE2ETest extends AbstractVerifierE2ETest {
                 fixture.getDocumentType(),
                 signatureId,
                 /*zipped*/ false,
-                material);
+                material,false);
 
         assertNotNull(signed, "signResponse null olmamalı (" + key + " / " + fixture + ")");
         assertNotNull(signed.getSignedDocument(),

--- a/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XadesSoftHsmVerifierE2ETest.java
+++ b/src/test/java/io/mersel/dss/signer/api/e2e/verifier/XadesSoftHsmVerifierE2ETest.java
@@ -6,6 +6,7 @@ import eu.europa.esig.dss.xades.signature.XAdESService;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningContext;
 import io.mersel.dss.signer.api.models.SigningMaterial;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.SigningMaterialFactory;
 import io.mersel.dss.signer.api.services.certificate.CertificateChainBuilderService;
 import io.mersel.dss.signer.api.services.certificate.CertificateValidatorService;
@@ -224,7 +225,7 @@ class XadesSoftHsmVerifierE2ETest extends AbstractVerifierE2ETest {
                 fixture.getDocumentType(),
                 signatureId,
                 /*zipped*/ false,
-                material,false);
+                material, XadesSignatureLevel.XADES_BES);
 
         assertNotNull(signed, "signResponse null olmamalı (" + key + " / " + fixture + ")");
         assertNotNull(signed.getSignedDocument(),

--- a/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESEcdsaSignatureFormatTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESEcdsaSignatureFormatTest.java
@@ -10,6 +10,7 @@ import io.mersel.dss.signer.api.e2e.verifier.PfxTestKey;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningMaterial;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.crypto.CryptoSignerService;
 import io.mersel.dss.signer.api.services.crypto.DigestAlgorithmResolverService;
 import io.mersel.dss.signer.api.services.crypto.SignatureAlgorithmResolverService;
@@ -114,7 +115,7 @@ class XAdESEcdsaSignatureFormatTest {
                 DocumentType.UblDocument,
                 "id-" + UUID.randomUUID().toString().replace("-", ""),
                 /*zipped*/ false,
-                material,false);
+                material, XadesSignatureLevel.XADES_BES);
 
         assertNotNull(signed.getSignedDocument(), "signedDocument null olmamalı");
 

--- a/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESEcdsaSignatureFormatTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESEcdsaSignatureFormatTest.java
@@ -114,7 +114,7 @@ class XAdESEcdsaSignatureFormatTest {
                 DocumentType.UblDocument,
                 "id-" + UUID.randomUUID().toString().replace("-", ""),
                 /*zipped*/ false,
-                material);
+                material,false);
 
         assertNotNull(signed.getSignedDocument(), "signedDocument null olmamalı");
 

--- a/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESLevelUpgradeServiceTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESLevelUpgradeServiceTest.java
@@ -5,7 +5,7 @@ import eu.europa.esig.dss.model.InMemoryDocument;
 import eu.europa.esig.dss.spi.validation.CertificateVerifier;
 import eu.europa.esig.dss.xades.XAdESSignatureParameters;
 import io.mersel.dss.signer.api.exceptions.TimestampException;
-import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.timestamp.TimestampConfigurationService;
 import io.qameta.allure.Epic;
 import io.qameta.allure.Feature;
@@ -26,8 +26,16 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+/**
+ * XAdESLevelUpgradeService kontrat testleri.
+ *
+ * <p>Karar verici sözleşmesi: imza seviyesi yalnızca {@link XadesSignatureLevel}
+ * parametresine bağlıdır; documentType (UblDocument, EArchiveReport vb.) bu
+ * servisin imzasına dahil değildir ve seviye kararına etki etmez. Parametre
+ * <strong>asla null olamaz</strong>; null safety DTO katmanında garanti edilir.</p>
+ */
 @Epic("Service Layer")
-@Feature("XAdES Level Upgrade (T/LT/LTA)")
+@Feature("XAdES Level Upgrade (request-driven)")
 @Severity(SeverityLevel.NORMAL)
 class XAdESLevelUpgradeServiceTest {
 
@@ -53,44 +61,37 @@ class XAdESLevelUpgradeServiceTest {
         return new XAdESSignatureParameters();
     }
 
+    /**
+     * level={@link XadesSignatureLevel#XADES_BES} geldiğinde upgrade akışına hiç
+     * girilmemeli; {@code timestampService}'e tek bir çağrı bile yapılmamalıdır.
+     * Bu, kontör tasarrufu kontratının özüdür.
+     */
     @Nested
-    class SkipUpgrade {
+    class NoUpgrade {
 
         @Test
-        void shouldSkipUpgradeForUblDocument() {
+        void shouldReturnOriginalDocumentWhenLevelIsXADES_BES() {
             DSSDocument original = createTestDocument();
 
-            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.UblDocument, createTestParameters(),false);
+            DSSDocument result = service.upgradeIfNeeded(
+                    original, createTestParameters(), XadesSignatureLevel.XADES_BES);
 
-            assertSame(original, result);
+            assertSame(original, result, "XADES_BES iken orijinal belge dönmeli");
             verifyNoInteractions(timestampService);
         }
 
+        /**
+         * Kritik test: TSA host'u <em>hiç</em> yapılandırılmamış olsa bile
+         * level=XADES_BES iken fail-fast tetiklenmemeli. Bu, e-Adisyon /
+         * e-Döviz rapor akışlarında TSA olmadan rapor üretme senaryosunun
+         * iş gerekçesidir.
+         */
         @Test
-        void shouldSkipUpgradeForHrXml() {
+        void shouldNotThrowEvenWhenTimestampServiceMisconfiguredAndLevelIsBes() {
             DSSDocument original = createTestDocument();
 
-            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.HrXml, createTestParameters(),false);
-
-            assertSame(original, result);
-            verifyNoInteractions(timestampService);
-        }
-
-        @Test
-        void shouldSkipUpgradeForOtherXmlDocument() {
-            DSSDocument original = createTestDocument();
-
-            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.OtherXmlDocument, createTestParameters(),false);
-
-            assertSame(original, result);
-            verifyNoInteractions(timestampService);
-        }
-
-        @Test
-        void shouldSkipUpgradeForNone() {
-            DSSDocument original = createTestDocument();
-
-            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.None, createTestParameters(),false);
+            DSSDocument result = service.upgradeIfNeeded(
+                    original, createTestParameters(), XadesSignatureLevel.XADES_BES);
 
             assertSame(original, result);
             verifyNoInteractions(timestampService);
@@ -98,14 +99,12 @@ class XAdESLevelUpgradeServiceTest {
     }
 
     /**
-     * EArchiveReport için XAdES-A yükseltmesi GİB tarafına gönderilen raporun
-     * uygunluğu için zorunludur. TSP yapılandırılmamışsa veya upgrade hata
-     * alırsa servis sessizce XAdES-B döndürmemeli — fail-fast olmalı ki
-     * client {@link TimestampException} → HTTP 503 / {@code TIMESTAMP_ERROR}
-     * görür ve işlemi tekrar denemeye / config'i düzeltmeye yönlenir.
+     * level={@link XadesSignatureLevel#XADES_A} açıkça istendiğinde fail-fast
+     * davranışı korunur: TSA yapılandırılmamışsa veya yükseltme hata alırsa
+     * {@link TimestampException} bubble eder; XADES_BES fallback üretilmez.
      */
     @Nested
-    class EArchiveReportUpgrade {
+    class XADES_A_UpgradeFailFast {
 
         @Test
         void shouldThrowTimestampExceptionWhenTimestampServiceUnavailable() {
@@ -114,11 +113,11 @@ class XAdESLevelUpgradeServiceTest {
             XAdESSignatureParameters parameters = createTestParameters();
 
             TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters,false));
+                    () -> service.upgradeIfNeeded(original, parameters, XadesSignatureLevel.XADES_A));
 
             assertEquals("TIMESTAMP_ERROR", ex.getErrorCode());
-            assertTrue(ex.getMessage().contains("EArchiveReport"),
-                    "Hata mesajı belge tipini içermeli ki client hangi rapor için TSP gerektiğini bilsin");
+            assertTrue(ex.getMessage().contains("XADES_A"),
+                    "Hata mesajı istenen profili içermeli ki client neyin başarısız olduğunu bilsin");
             assertTrue(ex.getMessage().contains("TS_SERVER_HOST"),
                     "Hata mesajı yapılandırılması gereken property'yi söylemeli");
             verify(timestampService).isAvailable();
@@ -126,7 +125,7 @@ class XAdESLevelUpgradeServiceTest {
         }
 
         @Test
-        void shouldThrowTimestampExceptionWhenUpgradeFails() {
+        void shouldBubbleOriginalTimestampExceptionWhenTspSourceFails() {
             when(timestampService.isAvailable()).thenReturn(true);
             when(timestampService.getTspSource())
                     .thenThrow(new TimestampException("TSP unavailable"));
@@ -134,7 +133,7 @@ class XAdESLevelUpgradeServiceTest {
             XAdESSignatureParameters parameters = createTestParameters();
 
             TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters,false));
+                    () -> service.upgradeIfNeeded(original, parameters, XadesSignatureLevel.XADES_A));
 
             assertEquals("TIMESTAMP_ERROR", ex.getErrorCode(),
                     "Orijinal TimestampException sarmalanmadan bubble etmeli ki error envelope korunabilsin");
@@ -151,51 +150,11 @@ class XAdESLevelUpgradeServiceTest {
             XAdESSignatureParameters parameters = createTestParameters();
 
             TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters,false));
+                    () -> service.upgradeIfNeeded(original, parameters, XadesSignatureLevel.XADES_A));
 
             assertEquals("TIMESTAMP_ERROR", ex.getErrorCode());
-            assertTrue(ex.getMessage().contains("EArchiveReport"));
-            assertTrue(ex.getMessage().contains("XAdES-A"),
-                    "Hata mesajı XAdES-A bağlamını net etmeli (XAdES-B yarım imza üretilmediği belirtilmeli)");
-        }
-    }
-
-    /**
-     * EBiletReport için aynı XAdES-A garantisi: TSP yoksa fail-fast,
-     * upgrade fail olursa fail-fast.
-     */
-    @Nested
-    class EBiletReportUpgrade {
-
-        @Test
-        void shouldThrowTimestampExceptionWhenTimestampServiceUnavailable() {
-            when(timestampService.isAvailable()).thenReturn(false);
-            DSSDocument original = createTestDocument();
-            XAdESSignatureParameters parameters = createTestParameters();
-
-            TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EBiletReport, parameters,false));
-
-            assertEquals("TIMESTAMP_ERROR", ex.getErrorCode());
-            assertTrue(ex.getMessage().contains("EBiletReport"));
-            verify(timestampService).isAvailable();
-            verify(timestampService, never()).getTspSource();
-        }
-
-        @Test
-        void shouldThrowTimestampExceptionWhenUpgradeFails() {
-            when(timestampService.isAvailable()).thenReturn(true);
-            when(timestampService.getTspSource())
-                    .thenThrow(new RuntimeException("TSP unreachable"));
-            DSSDocument original = createTestDocument();
-            XAdESSignatureParameters parameters = createTestParameters();
-
-            TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EBiletReport, parameters,false));
-
-            assertEquals("TIMESTAMP_ERROR", ex.getErrorCode());
-            verify(timestampService).isAvailable();
-            verify(timestampService).getTspSource();
+            assertTrue(ex.getMessage().contains("XADES_A"),
+                    "Hata mesajı XADES_A bağlamını net etmeli (XADES_BES yarım imza üretilmediği belirtilmeli)");
         }
     }
 }

--- a/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESLevelUpgradeServiceTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESLevelUpgradeServiceTest.java
@@ -60,7 +60,7 @@ class XAdESLevelUpgradeServiceTest {
         void shouldSkipUpgradeForUblDocument() {
             DSSDocument original = createTestDocument();
 
-            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.UblDocument, createTestParameters());
+            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.UblDocument, createTestParameters(),false);
 
             assertSame(original, result);
             verifyNoInteractions(timestampService);
@@ -70,7 +70,7 @@ class XAdESLevelUpgradeServiceTest {
         void shouldSkipUpgradeForHrXml() {
             DSSDocument original = createTestDocument();
 
-            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.HrXml, createTestParameters());
+            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.HrXml, createTestParameters(),false);
 
             assertSame(original, result);
             verifyNoInteractions(timestampService);
@@ -80,7 +80,7 @@ class XAdESLevelUpgradeServiceTest {
         void shouldSkipUpgradeForOtherXmlDocument() {
             DSSDocument original = createTestDocument();
 
-            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.OtherXmlDocument, createTestParameters());
+            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.OtherXmlDocument, createTestParameters(),false);
 
             assertSame(original, result);
             verifyNoInteractions(timestampService);
@@ -90,7 +90,7 @@ class XAdESLevelUpgradeServiceTest {
         void shouldSkipUpgradeForNone() {
             DSSDocument original = createTestDocument();
 
-            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.None, createTestParameters());
+            DSSDocument result = service.upgradeIfNeeded(original, DocumentType.None, createTestParameters(),false);
 
             assertSame(original, result);
             verifyNoInteractions(timestampService);
@@ -114,7 +114,7 @@ class XAdESLevelUpgradeServiceTest {
             XAdESSignatureParameters parameters = createTestParameters();
 
             TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters));
+                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters,false));
 
             assertEquals("TIMESTAMP_ERROR", ex.getErrorCode());
             assertTrue(ex.getMessage().contains("EArchiveReport"),
@@ -134,7 +134,7 @@ class XAdESLevelUpgradeServiceTest {
             XAdESSignatureParameters parameters = createTestParameters();
 
             TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters));
+                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters,false));
 
             assertEquals("TIMESTAMP_ERROR", ex.getErrorCode(),
                     "Orijinal TimestampException sarmalanmadan bubble etmeli ki error envelope korunabilsin");
@@ -151,7 +151,7 @@ class XAdESLevelUpgradeServiceTest {
             XAdESSignatureParameters parameters = createTestParameters();
 
             TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters));
+                    () -> service.upgradeIfNeeded(original, DocumentType.EArchiveReport, parameters,false));
 
             assertEquals("TIMESTAMP_ERROR", ex.getErrorCode());
             assertTrue(ex.getMessage().contains("EArchiveReport"));
@@ -174,7 +174,7 @@ class XAdESLevelUpgradeServiceTest {
             XAdESSignatureParameters parameters = createTestParameters();
 
             TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EBiletReport, parameters));
+                    () -> service.upgradeIfNeeded(original, DocumentType.EBiletReport, parameters,false));
 
             assertEquals("TIMESTAMP_ERROR", ex.getErrorCode());
             assertTrue(ex.getMessage().contains("EBiletReport"));
@@ -191,7 +191,7 @@ class XAdESLevelUpgradeServiceTest {
             XAdESSignatureParameters parameters = createTestParameters();
 
             TimestampException ex = assertThrows(TimestampException.class,
-                    () -> service.upgradeIfNeeded(original, DocumentType.EBiletReport, parameters));
+                    () -> service.upgradeIfNeeded(original, DocumentType.EBiletReport, parameters,false));
 
             assertEquals("TIMESTAMP_ERROR", ex.getErrorCode());
             verify(timestampService).isAvailable();

--- a/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESSigningTimeFormatTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESSigningTimeFormatTest.java
@@ -10,6 +10,7 @@ import io.mersel.dss.signer.api.e2e.verifier.PfxTestKey;
 import io.mersel.dss.signer.api.models.SignResponse;
 import io.mersel.dss.signer.api.models.SigningMaterial;
 import io.mersel.dss.signer.api.models.enums.DocumentType;
+import io.mersel.dss.signer.api.models.enums.XadesSignatureLevel;
 import io.mersel.dss.signer.api.services.crypto.CryptoSignerService;
 import io.mersel.dss.signer.api.services.crypto.DigestAlgorithmResolverService;
 import io.mersel.dss.signer.api.services.crypto.SignatureAlgorithmResolverService;
@@ -143,7 +144,7 @@ class XAdESSigningTimeFormatTest {
                 DocumentType.UblDocument,
                 "id-" + UUID.randomUUID().toString().replace("-", ""),
                 /*zipped*/ false,
-                material,false);
+                material, XadesSignatureLevel.XADES_BES);
 
         assertNotNull(signed.getSignedDocument(), "signedDocument null olmamalı");
 

--- a/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESSigningTimeFormatTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/services/signature/xades/XAdESSigningTimeFormatTest.java
@@ -143,7 +143,7 @@ class XAdESSigningTimeFormatTest {
                 DocumentType.UblDocument,
                 "id-" + UUID.randomUUID().toString().replace("-", ""),
                 /*zipped*/ false,
-                material);
+                material,false);
 
         assertNotNull(signed.getSignedDocument(), "signedDocument null olmamalı");
 


### PR DESCRIPTION
E-adisyon raporu ve edöviz raporu(e-döviz iptal raporu hariç) zaman damgası bulundurmadan raporlanabilmektedir. Gereksiz kontör harcamasını engellemek için zaman damgasının atılmaması istek atarken dışarıdan değiştirilebilir hale getirilmiştir. Varsayılan olarak eskisi gibi zaman damgası atacaktır.

## 📝 Değişiklik Açıklaması

Zaman damgası atma işlemi parametrik olarak istek bazında kapatılabilir.

## 🎯 Değişiklik Türü

- [ ] 🐛 Bug fix (geriye uyumlu hata düzeltmesi)
- [x] ✨ Yeni özellik (geriye uyumlu yeni işlevsellik)
- [ ] 💥 Breaking change (geriye uyumsuz değişiklik)
- [ ] 📝 Dokümantasyon güncellesi
- [ ] ♻️ Refactoring (davranış değişikliği olmadan kod iyileştirme)
- [ ] ⚡ Performance iyileştirmesi
- [x] 🧪 Test ekleme/güncelleme

## 🧪 Testler

- [ ] Yeni unit testler eklendi
- [x] Mevcut testler güncellendi
- [x] Tüm testler başarılı (`mvn test`)
- [x] Manuel olarak test edildi

## 📋 Kontrol Listesi

- [x] Kod standartlarına uygun (Javadoc, isimlendirme)
- [x] Commit mesajları açıklayıcı
- [ ] CHANGELOG.md güncellendi (major değişiklikler için)
- [ ] README.md güncellendi (gerekirse)
- [x] Linter hataları yok
- [ ] Breaking change ise migration guide eklendi

## 📸 Ekran Görüntüleri (varsa)
v1/xadessign request body kısmına default false olacak şekilde 'DisableTimeStamp' parametresi eklendi.

