### PR TITLE
Fix/thread safety security hardening

### DIFF
--- a/src/main/java/io/mersel/dss/signer/api/GlobalExceptionHandler.java
+++ b/src/main/java/io/mersel/dss/signer/api/GlobalExceptionHandler.java
@@ -54,9 +54,11 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(io.mersel.dss.signer.api.exceptions.KeyStoreException.class)
     public ResponseEntity<ErrorModel> handleKeyStoreException(
             io.mersel.dss.signer.api.exceptions.KeyStoreException ex) {
+        // Tam detay (keystore yolu, alias, serial vb.) yalnızca sunucu log'una;
+        // HTTP yanıtına konmaz — aksi halde dosya sistemi/HSM yerleşimi ifşa olur.
         LOGGER.error("KeyStore işlemi başarısız: {}", ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(new ErrorModel(ex.getErrorCode(), ex.getMessage()));
+            .body(new ErrorModel(ex.getErrorCode(), "Anahtar deposu işlemi başarısız oldu."));
     }
 
     /**
@@ -111,10 +113,11 @@ public class GlobalExceptionHandler {
         UnrecoverableKeyException.class
     })
     public ResponseEntity<ErrorModel> handleSecurityException(Exception ex) {
+        // Sertifika/anahtar hatalarının ayrıntısı (yanlış PIN, alias, algoritma vb.)
+        // istemciye sızdırılmaz; yalnızca sunucu log'una yazılır.
         LOGGER.error("Güvenlik işlemi başarısız: {}", ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(new ErrorModel("SECURITY_ERROR", 
-                "Bir güvenlik hatası oluştu: " + ex.getMessage()));
+            .body(new ErrorModel("SECURITY_ERROR", "Bir güvenlik hatası oluştu."));
     }
 
     /**

--- a/src/main/java/io/mersel/dss/signer/api/constants/XmlConstants.java
+++ b/src/main/java/io/mersel/dss/signer/api/constants/XmlConstants.java
@@ -1,31 +1,36 @@
 package io.mersel.dss.signer.api.constants;
 
-public class XmlConstants {
+public final class XmlConstants {
+
+    private XmlConstants() {
+        // Salt sabit taşıyıcı; örneklenmemeli.
+    }
+
     // WS-Security Namespaces
-    public static String NS_WSSE = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
-    public static String NS_WSU = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
+    public static final String NS_WSSE = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-secext-1.0.xsd";
+    public static final String NS_WSU = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd";
 
     // WS-Security Attributes
-    public static String ATTR_EncodingType = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary";
-    public static String ATTR_ValueType = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3";
-    public static String ATTR_Soap_1_Dot_2_ValueType = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509PKIPathv1";
+    public static final String ATTR_EncodingType = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-soap-message-security-1.0#Base64Binary";
+    public static final String ATTR_ValueType = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509v3";
+    public static final String ATTR_Soap_1_Dot_2_ValueType = "http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-x509-token-profile-1.0#X509PKIPathv1";
 
     // SOAP Namespaces
-    public static String NS_SOAP_ENVELOPE = "http://schemas.xmlsoap.org/soap/envelope/";
-    public static String NS_SOAP_1_DOT_2_ENVELOPE = "http://www.w3.org/2003/05/soap-envelope";
+    public static final String NS_SOAP_ENVELOPE = "http://schemas.xmlsoap.org/soap/envelope/";
+    public static final String NS_SOAP_1_DOT_2_ENVELOPE = "http://www.w3.org/2003/05/soap-envelope";
 
     // UBL Namespace
-    public static String NS_UBL_EXTENSION = "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2";
+    public static final String NS_UBL_EXTENSION = "urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2";
 
     // e-Arşiv Namespace
-    public static String NS_EARSIV = "http://earsiv.efatura.gov.tr";
+    public static final String NS_EARSIV = "http://earsiv.efatura.gov.tr";
 
     // e-Bilet Namespace
-    public static String NS_BILET = "http://ebilet.efatura.gov.tr";
+    public static final String NS_BILET = "http://ebilet.efatura.gov.tr";
 
     // HR-XML / Open Applications Namespace
-    public static String NS_OAGIS = "http://www.openapplications.org/oagis/9";
+    public static final String NS_OAGIS = "http://www.openapplications.org/oagis/9";
 
     // Signature Algorithm
-    public static String SignatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+    public static final String SignatureAlgorithm = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
 }

--- a/src/main/java/io/mersel/dss/signer/api/controllers/CertificateInfoController.java
+++ b/src/main/java/io/mersel/dss/signer/api/controllers/CertificateInfoController.java
@@ -5,7 +5,6 @@ import io.mersel.dss.signer.api.models.configurations.SignatureServiceConfigurat
 import io.mersel.dss.signer.api.services.CertificateInfoService;
 import io.mersel.dss.signer.api.services.keystore.KeyStoreProvider;
 import io.mersel.dss.signer.api.services.keystore.PKCS11KeyStoreProvider;
-import io.mersel.dss.signer.api.services.keystore.PfxKeyStoreProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -90,7 +89,8 @@ public class CertificateInfoController {
 
             Map<String, Object> errorResponse = new HashMap<>();
             errorResponse.put("success", false);
-            errorResponse.put("error", e.getMessage());
+            // Ham exception mesajı istemciye sızdırılmaz (iç detay ifşasını önlemek için)
+            errorResponse.put("error", "Sertifika listesi alınamadı.");
 
             return ResponseEntity.status(500).body(errorResponse);
         }
@@ -116,19 +116,20 @@ public class CertificateInfoController {
             info.put("success", true);
             info.put("keystoreType", keyStoreProvider.getType());
 
+            // NOT: Dosya sistemi (pfxPath) ve HSM kütüphane yolu (library) bilinçli
+            // olarak yanıta konmaz — bunlar sunucunun iç yerleşimini ifşa eder ve
+            // saldırgan için keşif değeri taşır. Yalnızca fonksiyonel kimlikler döner.
             if (keyStoreProvider instanceof PKCS11KeyStoreProvider) {
-                info.put("library", config.getPkcs11LibraryPath());
                 info.put("slot", config.getPkcs11Slot());
-            } else if (keyStoreProvider instanceof PfxKeyStoreProvider) {
-                info.put("pfxPath", config.getPfxPath());
             }
 
             info.put("certificateAlias", config.getCertificateAlias());
             info.put("certificateSerialNumber", config.getCertificateSerialNumber());
 
         } catch (Exception e) {
+            LOGGER.error("Keystore bilgisi alınamadı", e);
             info.put("success", false);
-            info.put("error", e.getMessage());
+            info.put("error", "Keystore bilgisi alınamadı.");
         }
 
         return ResponseEntity.ok(info);

--- a/src/main/java/io/mersel/dss/signer/api/services/AbstractKamuSMXmlDepoResolver.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/AbstractKamuSMXmlDepoResolver.java
@@ -2,9 +2,8 @@ package io.mersel.dss.signer.api.services;
 
 import eu.europa.esig.dss.model.x509.CertificateToken;
 import eu.europa.esig.dss.spi.x509.CommonTrustedCertificateSource;
+import io.mersel.dss.signer.api.util.SecurityProviderInitializer;
 import io.mersel.dss.signer.api.util.xml.SecureXmlFactories;
-import org.apache.commons.io.IOUtils;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -14,7 +13,7 @@ import org.w3c.dom.NodeList;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import java.io.ByteArrayInputStream;
-import java.security.Security;
+import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -34,10 +33,10 @@ public abstract class AbstractKamuSMXmlDepoResolver implements TrustedRootCertif
     protected final AtomicReference<List<X509Certificate>> trustedRoots = new AtomicReference<>(Collections.emptyList());
     protected final AtomicReference<List<CertificateToken>> trustedRootTokens = new AtomicReference<>(Collections.emptyList());
     
-    protected CommonTrustedCertificateSource trustedCertificateSource;
+    protected volatile CommonTrustedCertificateSource trustedCertificateSource;
 
     static {
-        Security.addProvider(new BouncyCastleProvider());
+        SecurityProviderInitializer.ensureBouncyCastle();
     }
 
     /**
@@ -54,7 +53,7 @@ public abstract class AbstractKamuSMXmlDepoResolver implements TrustedRootCertif
         // yine kapalı (DOCTYPE reddedilir).
         DocumentBuilderFactory dbf = SecureXmlFactories.newDocumentBuilderFactory(false);
         DocumentBuilder builder = dbf.newDocumentBuilder();
-        Document document = builder.parse(new ByteArrayInputStream(xmlBody.getBytes()));
+        Document document = builder.parse(new ByteArrayInputStream(xmlBody.getBytes(StandardCharsets.UTF_8)));
 
         List<String> values = new ArrayList<String>();
 
@@ -109,17 +108,19 @@ public abstract class AbstractKamuSMXmlDepoResolver implements TrustedRootCertif
      * Trusted certificate source'u gunceller
      */
     protected void updateTrustedCertificateSource() {
-        if (trustedCertificateSource == null) {
-            trustedCertificateSource = new CommonTrustedCertificateSource();
-        }
-        
-        // KamuSM sertifikalarini ekle
+        // Her yenilemede sıfırdan bir kaynak kurulup atomik olarak yayımlanır:
+        //  (1) request thread'leri mutasyona uğrayan bir koleksiyonu okumaz
+        //      (volatile alana tek atama ile güvenli yayım),
+        //  (2) depodan kaldırılan kökler bir sonraki yenilemede güven listesinden
+        //      gerçekten düşer (eskisi additive olduğu için düşmüyordu).
+        CommonTrustedCertificateSource newSource = new CommonTrustedCertificateSource();
         for (CertificateToken token : trustedRootTokens.get()) {
-            trustedCertificateSource.addCertificate(token);
+            newSource.addCertificate(token);
         }
-        
-        logger.info("Trusted certificate source updated with {} certificates", 
-            trustedCertificateSource.getCertificates().size());
+        this.trustedCertificateSource = newSource;
+
+        logger.info("Trusted certificate source updated with {} certificates",
+            newSource.getCertificates().size());
     }
 
     @Override
@@ -134,18 +135,22 @@ public abstract class AbstractKamuSMXmlDepoResolver implements TrustedRootCertif
 
     @Override
     public CommonTrustedCertificateSource getTrustedCertificateSource() {
-        if (trustedCertificateSource == null) {
+        CommonTrustedCertificateSource local = trustedCertificateSource;
+        if (local == null) {
             updateTrustedCertificateSource();
+            local = trustedCertificateSource;
         }
-        return trustedCertificateSource;
+        return local;
     }
 
     @Override
-    public void addTrustedCertificate(CertificateToken certificate) {
-        if (trustedCertificateSource == null) {
-            trustedCertificateSource = new CommonTrustedCertificateSource();
+    public synchronized void addTrustedCertificate(CertificateToken certificate) {
+        CommonTrustedCertificateSource local = trustedCertificateSource;
+        if (local == null) {
+            local = new CommonTrustedCertificateSource();
+            trustedCertificateSource = local;
         }
-        trustedCertificateSource.addCertificate(certificate);
+        local.addCertificate(certificate);
         logger.info("Added trusted certificate: {}", certificate.getSubject());
     }
 

--- a/src/main/java/io/mersel/dss/signer/api/services/CertificateFolderResolver.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/CertificateFolderResolver.java
@@ -2,7 +2,8 @@ package io.mersel.dss.signer.api.services;
 
 import eu.europa.esig.dss.model.x509.CertificateToken;
 import eu.europa.esig.dss.spi.x509.CommonTrustedCertificateSource;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import io.mersel.dss.signer.api.util.SecurityProviderInitializer;
+import io.mersel.dss.signer.api.util.Utilities;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -13,7 +14,6 @@ import org.springframework.stereotype.Service;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.security.Security;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
@@ -36,46 +36,17 @@ public class CertificateFolderResolver implements TrustedRootCertificateResolver
     private final AtomicReference<List<X509Certificate>> trustedRoots = new AtomicReference<>(Collections.emptyList());
     private final AtomicReference<List<CertificateToken>> trustedRootTokens = new AtomicReference<>(Collections.emptyList());
     
-    private CommonTrustedCertificateSource trustedCertificateSource;
+    private volatile CommonTrustedCertificateSource trustedCertificateSource;
 
     static {
-        Security.addProvider(new BouncyCastleProvider());
+        SecurityProviderInitializer.ensureBouncyCastle();
     }
 
     public CertificateFolderResolver(ResourceLoader resourceLoader,
                                      @Value("${trusted.root.cert.folder.path:}") String folderPath) {
         this.resourceLoader = resourceLoader;
-        // Path'teki baştaki ve sondaki tırnakları temizle (Spring properties'te çift tırnak kullanımı için)
-        if (folderPath != null) {
-            folderPath = folderPath.trim();
-            // Çift tırnak veya tek tırnak ile başlayıp bitiyorsa kaldır
-            if ((folderPath.startsWith("\"") && folderPath.endsWith("\"")) ||
-                (folderPath.startsWith("'") && folderPath.endsWith("'"))) {
-                folderPath = folderPath.substring(1, folderPath.length() - 1);
-            }
-            // Encoding sorununu çöz: Eğer path ISO-8859-1 olarak yanlış okunduysa UTF-8'e çevir
-            try {
-                // ISO-8859-1 olarak yanlış okunmuş gibi görünen karakterleri UTF-8'e çevir
-                // Örnek: "Ãn" -> "Ön", "HazÄ±rlÄ±k" -> "Hazırlık"
-                if (folderPath.contains("Ã") || folderPath.contains("Ä")) {
-                    byte[] bytes = folderPath.getBytes("ISO-8859-1");
-                    String correctedPath = new String(bytes, "UTF-8");
-                    // Eğer düzeltilmiş path Türkçe karakterler içeriyorsa kullan
-                    if (correctedPath.contains("Ö") || correctedPath.contains("ö") || 
-                        correctedPath.contains("ı") || correctedPath.contains("İ") ||
-                        correctedPath.contains("ş") || correctedPath.contains("Ş") ||
-                        correctedPath.contains("ğ") || correctedPath.contains("Ğ") ||
-                        correctedPath.contains("ü") || correctedPath.contains("Ü") ||
-                        correctedPath.contains("ç") || correctedPath.contains("Ç")) {
-                        folderPath = correctedPath;
-                        LOGGER.debug("Path encoding düzeltildi: {}", folderPath);
-                    }
-                }
-            } catch (Exception e) {
-                LOGGER.debug("Path encoding düzeltme hatası: {}", e.getMessage());
-            }
-        }
-        this.folderPath = folderPath;
+        // Tırnak temizleme + ISO-8859-1/UTF-8 mojibake onarımı ortak yardımcıda
+        this.folderPath = Utilities.sanitizeConfiguredPath(folderPath);
     }
 
     @Override
@@ -205,17 +176,19 @@ public class CertificateFolderResolver implements TrustedRootCertificateResolver
      * Trusted certificate source'u gunceller
      */
     private void updateTrustedCertificateSource() {
-        if (trustedCertificateSource == null) {
-            trustedCertificateSource = new CommonTrustedCertificateSource();
-        }
-        
-        // Klasörden yüklenen sertifikaları ekle
+        // Her yenilemede sıfırdan bir kaynak kurulup atomik olarak yayımlanır:
+        //  (1) request thread'leri mutasyona uğrayan bir koleksiyonu okumaz
+        //      (volatile alana tek atama ile güvenli yayım),
+        //  (2) klasörden kaldırılan sertifikalar bir sonraki yenilemede güven
+        //      listesinden gerçekten düşer (eskisi additive olduğu için düşmüyordu).
+        CommonTrustedCertificateSource newSource = new CommonTrustedCertificateSource();
         for (CertificateToken token : trustedRootTokens.get()) {
-            trustedCertificateSource.addCertificate(token);
+            newSource.addCertificate(token);
         }
-        
-        LOGGER.info("Trusted certificate source updated with {} certificates", 
-            trustedCertificateSource.getCertificates().size());
+        this.trustedCertificateSource = newSource;
+
+        LOGGER.info("Trusted certificate source updated with {} certificates",
+            newSource.getCertificates().size());
     }
 
     @Override
@@ -230,18 +203,22 @@ public class CertificateFolderResolver implements TrustedRootCertificateResolver
 
     @Override
     public CommonTrustedCertificateSource getTrustedCertificateSource() {
-        if (trustedCertificateSource == null) {
+        CommonTrustedCertificateSource local = trustedCertificateSource;
+        if (local == null) {
             updateTrustedCertificateSource();
+            local = trustedCertificateSource;
         }
-        return trustedCertificateSource;
+        return local;
     }
 
     @Override
-    public void addTrustedCertificate(CertificateToken certificate) {
-        if (trustedCertificateSource == null) {
-            trustedCertificateSource = new CommonTrustedCertificateSource();
+    public synchronized void addTrustedCertificate(CertificateToken certificate) {
+        CommonTrustedCertificateSource local = trustedCertificateSource;
+        if (local == null) {
+            local = new CommonTrustedCertificateSource();
+            trustedCertificateSource = local;
         }
-        trustedCertificateSource.addCertificate(certificate);
+        local.addCertificate(certificate);
         LOGGER.info("Added trusted certificate: {}", certificate.getSubject());
     }
 

--- a/src/main/java/io/mersel/dss/signer/api/services/KamuSMXmlDepoOfflineResolver.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/KamuSMXmlDepoOfflineResolver.java
@@ -1,5 +1,6 @@
 package io.mersel.dss.signer.api.services;
 
+import io.mersel.dss.signer.api.util.Utilities;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.Resource;
@@ -31,37 +32,8 @@ public class KamuSMXmlDepoOfflineResolver extends AbstractKamuSMXmlDepoResolver 
     public KamuSMXmlDepoOfflineResolver(ResourceLoader resourceLoader,
                                           @Value("${kamusm.root.offline.path:}") String xmlFilePath) {
         this.resourceLoader = resourceLoader;
-        // Path'teki baştaki ve sondaki tırnakları temizle (Spring properties'te çift tırnak kullanımı için)
-        if (xmlFilePath != null) {
-            xmlFilePath = xmlFilePath.trim();
-            // Çift tırnak veya tek tırnak ile başlayıp bitiyorsa kaldır
-            if ((xmlFilePath.startsWith("\"") && xmlFilePath.endsWith("\"")) ||
-                (xmlFilePath.startsWith("'") && xmlFilePath.endsWith("'"))) {
-                xmlFilePath = xmlFilePath.substring(1, xmlFilePath.length() - 1);
-            }
-            // Encoding sorununu çöz: Eğer path ISO-8859-1 olarak yanlış okunduysa UTF-8'e çevir
-            try {
-                // ISO-8859-1 olarak yanlış okunmuş gibi görünen karakterleri UTF-8'e çevir
-                // Örnek: "Ãn" -> "Ön", "HazÄ±rlÄ±k" -> "Hazırlık"
-                if (xmlFilePath.contains("Ã") || xmlFilePath.contains("Ä")) {
-                    byte[] bytes = xmlFilePath.getBytes("ISO-8859-1");
-                    String correctedPath = new String(bytes, "UTF-8");
-                    // Eğer düzeltilmiş path Türkçe karakterler içeriyorsa kullan
-                    if (correctedPath.contains("Ö") || correctedPath.contains("ö") || 
-                        correctedPath.contains("ı") || correctedPath.contains("İ") ||
-                        correctedPath.contains("ş") || correctedPath.contains("Ş") ||
-                        correctedPath.contains("ğ") || correctedPath.contains("Ğ") ||
-                        correctedPath.contains("ü") || correctedPath.contains("Ü") ||
-                        correctedPath.contains("ç") || correctedPath.contains("Ç")) {
-                        xmlFilePath = correctedPath;
-                        logger.debug("Path encoding düzeltildi: {}", xmlFilePath);
-                    }
-                }
-            } catch (Exception e) {
-                logger.debug("Path encoding düzeltme hatası: {}", e.getMessage());
-            }
-        }
-        this.xmlFilePath = xmlFilePath;
+        // Tırnak temizleme + ISO-8859-1/UTF-8 mojibake onarımı ortak yardımcıda
+        this.xmlFilePath = Utilities.sanitizeConfiguredPath(xmlFilePath);
     }
 
     @Override
@@ -121,7 +93,7 @@ public class KamuSMXmlDepoOfflineResolver extends AbstractKamuSMXmlDepoResolver 
         // - C:/path/to/file.xml (Windows absolute path with forward slash)
         boolean isDirectFileSystemPath = xmlFilePath.startsWith("file:") || 
                                          xmlFilePath.startsWith("/") || 
-                                         (xmlFilePath.length() >= 2 && xmlFilePath.charAt(1) == ':' && 
+                                         (xmlFilePath.length() >= 3 && xmlFilePath.charAt(1) == ':' &&
                                           (xmlFilePath.charAt(2) == '\\' || xmlFilePath.charAt(2) == '/')) ||
                                          (!xmlFilePath.startsWith("classpath:") && !xmlFilePath.startsWith("http"));
         

--- a/src/main/java/io/mersel/dss/signer/api/services/KamuSMXmlDepoOnlineResolver.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/KamuSMXmlDepoOnlineResolver.java
@@ -43,6 +43,16 @@ public class KamuSMXmlDepoOnlineResolver extends AbstractKamuSMXmlDepoResolver {
                 .build();
         this.resourceLoader = resourceLoader;
         this.rootUrl = rootUrl;
+
+        // Güven listesi (trust anchor) düz HTTP üzerinden çekiliyorsa uyar: bu kanal
+        // MITM'e açıktır — saldırgan yanıtı değiştirip sahte bir kök enjekte ederse
+        // ona zincirlenen sahte imzalar "geçerli" görünebilir. Kalıcı çözüm HTTPS +
+        // imza/pin doğrulaması ya da çevrimdışı (dosya) resolver kullanmaktır.
+        if (rootUrl != null && rootUrl.toLowerCase().startsWith("http://")) {
+            logger.warn("GUVENLIK UYARISI: KamuSM kok sertifika deposu duz HTTP uzerinden cekiliyor ({}). "
+                    + "MITM riski var; 'kamusm.root.url' degerini mumkunse HTTPS bir kaynaga alin "
+                    + "veya cevrimdisi resolver kullanin.", rootUrl);
+        }
     }
 
     @Override

--- a/src/main/java/io/mersel/dss/signer/api/services/notification/SignerNotifier.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/notification/SignerNotifier.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import io.mersel.dss.signer.api.config.LogHeadersFilter;
 import io.mersel.dss.signer.api.config.SignerNotificationConfiguration;
 import io.mersel.dss.signer.api.exceptions.SignatureException;
+import io.mersel.dss.signer.api.util.CryptoUtils;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.MediaType;
@@ -1054,11 +1055,7 @@ public class SignerNotifier {
             Mac mac = Mac.getInstance(HMAC_ALGORITHM);
             mac.init(new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), HMAC_ALGORITHM));
             byte[] raw = mac.doFinal(message.getBytes(StandardCharsets.UTF_8));
-            StringBuilder hex = new StringBuilder(raw.length * 2);
-            for (byte b : raw) {
-                hex.append(String.format("%02x", b & 0xff));
-            }
-            return hex.toString();
+            return CryptoUtils.bytesToHex(raw);
         } catch (Exception e) {
             logger.warn("HMAC-SHA256 hesaplanamadı: {}", e.getMessage());
             return null;
@@ -1090,11 +1087,7 @@ public class SignerNotifier {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");
             byte[] hash = md.digest(bytes);
-            StringBuilder sb = new StringBuilder(hash.length * 2);
-            for (byte b : hash) {
-                sb.append(String.format("%02x", b & 0xff));
-            }
-            return sb.toString();
+            return CryptoUtils.bytesToHex(hash);
         } catch (NoSuchAlgorithmException e) {
             // SHA-256 her JRE'de zorunlu — pratikte buraya düşmez.
             return null;

--- a/src/main/java/io/mersel/dss/signer/api/services/signature/pades/PAdESSignatureService.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/signature/pades/PAdESSignatureService.java
@@ -81,8 +81,9 @@ public class PAdESSignatureService {
                                String attachmentFileName,
                                boolean appendMode,
                                SigningMaterial material) {
+        PdfReader reader = null;
         try {
-            PdfReader reader = new PdfReader(pdfInputStream);
+            reader = new PdfReader(pdfInputStream);
             ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
             PdfStamper stamper = PdfStamper.createSignature(
                 reader, outputStream, '\0', null, appendMode);
@@ -127,6 +128,13 @@ public class PAdESSignatureService {
         } catch (Exception e) {
             LOGGER.error("PAdES imzası oluşturulurken hata", e);
             throw new SignatureException("PAdES imzası oluşturulamadı", e);
+        } finally {
+            // PdfReader alttaki multipart temp-file handle'ını tutar; başarı ve
+            // hata yolunun her ikisinde de kapatılmalı (aksi halde özellikle
+            // Windows'ta temp dosya silinemez / handle sızar).
+            if (reader != null) {
+                reader.close();
+            }
         }
     }
 

--- a/src/main/java/io/mersel/dss/signer/api/services/timestamp/TimestampService.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/timestamp/TimestampService.java
@@ -20,7 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
 import java.security.MessageDigest;
-import java.text.SimpleDateFormat;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.*;
 
 /**
@@ -32,10 +33,16 @@ import java.util.*;
 public class TimestampService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(TimestampService.class);
-    private static final SimpleDateFormat ISO_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-    
-    static {
-        ISO_DATE_FORMAT.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+    // SimpleDateFormat thread-safe degildir; bu servis singleton olup timestamp
+    // uclari paralel isteklerde ayni ornek uzerinden format() cagirdigi icin
+    // immutable ve thread-safe DateTimeFormatter kullaniliyor. Pattern'deki 'Z'
+    // literal olup cikti bicimi (yyyy-MM-dd'T'HH:mm:ss'Z', UTC) aynen korunur.
+    private static final DateTimeFormatter ISO_DATE_FORMAT =
+            DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss'Z'").withZone(ZoneOffset.UTC);
+
+    private static String formatIsoUtc(Date date) {
+        return ISO_DATE_FORMAT.format(date.toInstant());
     }
 
     private final TimestampConfigurationService timestampConfigurationService;
@@ -98,7 +105,7 @@ public class TimestampService {
             // Response DTO'yu oluştur
             TimestampResponseDto response = new TimestampResponseDto();
             response.setTimestampToken(Base64.getEncoder().encodeToString(timestampBytes));
-            response.setTimestamp(ISO_DATE_FORMAT.format(dssToken.getGenerationTime()));
+            response.setTimestamp(formatIsoUtc(dssToken.getGenerationTime()));
             response.setHashAlgorithm(digestAlgorithm.getName());
             response.setSerialNumber(dssToken.getDSSIdAsString());
             
@@ -171,7 +178,7 @@ public class TimestampService {
             }
             
             // Temel bilgileri doldur (BouncyCastle token'dan)
-            response.setTimestamp(ISO_DATE_FORMAT.format(bcToken.getTimeStampInfo().getGenTime()));
+            response.setTimestamp(formatIsoUtc(bcToken.getTimeStampInfo().getGenTime()));
             
             // Hash algoritmasını hem isim hem OID olarak set et
             String hashAlgOid = bcToken.getTimeStampInfo().getHashAlgorithm().getAlgorithm().getId();
@@ -244,8 +251,8 @@ public class TimestampService {
                 
                 // Sertifika geçerlilik tarihlerini kontrol et
                 Date now = new Date();
-                response.setCertificateNotBefore(ISO_DATE_FORMAT.format(signerCert.getNotBefore()));
-                response.setCertificateNotAfter(ISO_DATE_FORMAT.format(signerCert.getNotAfter()));
+                response.setCertificateNotBefore(formatIsoUtc(signerCert.getNotBefore()));
+                response.setCertificateNotAfter(formatIsoUtc(signerCert.getNotAfter()));
                 
                 boolean certValid = now.after(signerCert.getNotBefore()) && now.before(signerCert.getNotAfter());
                 response.setCertificateValid(certValid);

--- a/src/main/java/io/mersel/dss/signer/api/services/util/CompressionService.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/util/CompressionService.java
@@ -1,7 +1,6 @@
 package io.mersel.dss.signer.api.services.util;
 
 import io.mersel.dss.signer.api.exceptions.SignatureException;
-import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Service;
 
 import java.io.ByteArrayOutputStream;
@@ -19,31 +18,38 @@ import java.util.zip.ZipOutputStream;
 public class CompressionService {
 
     /**
+     * Bir ZIP girdisinin açılırken ulaşabileceği azami boyut (decompression bomb
+     * korumasi). Meşru e-fatura/e-arşiv içerikleri bunun çok altındadır; bu sınır
+     * yalnızca kötü niyetli, aşırı sıkıştırılmış ("zip bomb") girdileri engeller.
+     */
+    private static final long MAX_DECOMPRESSED_BYTES = 100L * 1024 * 1024; // 100 MB
+    private static final int COPY_BUFFER_SIZE = 8192;
+
+    /**
      * Byte dizisini belirtilen girdi adıyla ZIP formatında sıkıştırır.
-     * 
+     *
      * @param filename ZIP dosyasındaki girdi adı
      * @param content Sıkıştırılacak içerik
      * @return Sıkıştırılmış ZIP byte'ları
      */
     public byte[] zipBytes(String filename, byte[] content) {
-        try {
-            ByteArrayOutputStream baos = new ByteArrayOutputStream();
-            ZipOutputStream zos = new ZipOutputStream(baos);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
             ZipEntry entry = new ZipEntry(filename);
             entry.setSize(content.length);
             zos.putNextEntry(entry);
             zos.write(content);
             zos.closeEntry();
-            zos.close();
-            return baos.toByteArray();
         } catch (IOException e) {
             throw new SignatureException("İçerik sıkıştırılamadı", e);
         }
+        return baos.toByteArray();
     }
 
     /**
-     * ZIP input stream'den ilk girdiyi çıkarır.
-     * 
+     * ZIP input stream'den ilk girdiyi çıkarır. Açılan içerik
+     * {@link #MAX_DECOMPRESSED_BYTES} sınırını aşarsa hata verir (zip bomb koruması).
+     *
      * @param inputStream ZIP input stream
      * @return Sıkıştırılmamış içerik
      */
@@ -53,10 +59,22 @@ public class CompressionService {
                 StandardCharsets.ISO_8859_1
         )) {
             ZipEntry entry = zipInputStream.getNextEntry();
-            if (entry != null) {
-                return IOUtils.toByteArray(zipInputStream);
+            if (entry == null) {
+                throw new SignatureException("ZIP arşivi girdi içermiyor");
             }
-            throw new SignatureException("ZIP arşivi girdi içermiyor");
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            byte[] buffer = new byte[COPY_BUFFER_SIZE];
+            long total = 0;
+            int read;
+            while ((read = zipInputStream.read(buffer)) != -1) {
+                total += read;
+                if (total > MAX_DECOMPRESSED_BYTES) {
+                    throw new SignatureException(
+                            "ZIP içeriği izin verilen azami boyutu aşıyor (olası zip bomb)");
+                }
+                out.write(buffer, 0, read);
+            }
+            return out.toByteArray();
         } catch (IOException e) {
             throw new SignatureException("ZIP içeriği çıkarılamadı", e);
         }

--- a/src/main/java/io/mersel/dss/signer/api/services/validation/SignatureValidationService.java
+++ b/src/main/java/io/mersel/dss/signer/api/services/validation/SignatureValidationService.java
@@ -173,11 +173,17 @@ public class SignatureValidationService {
                 }
             }
 
-            return false; // Conservative: allow if inconclusive
+            // Fail-closed: DSS zaten TOTAL_PASSED dışı bir sonuç döndürdü ve imza
+            // sertifikasının güvenilir köke ulaştığını gösteremedik. Bu durumu
+            // "kabul edilebilir" saymak fail-open olurdu; imza zinciri sorunu say.
+            LOGGER.error("Signing certificate chain could not be established to a trusted root");
+            return true;
 
         } catch (Exception e) {
-            LOGGER.warn("Error checking signing certificate chain: {}", e.getMessage());
-            return false; // Don't block on analysis errors
+            // Fail-closed: güvenlik analizi sırasında hata olması "geçerli" anlamına
+            // gelmez. Doğrulayamadığımız bir zinciri reddediyoruz.
+            LOGGER.error("Error checking signing certificate chain, treating as invalid: {}", e.getMessage(), e);
+            return true;
         }
     }
 

--- a/src/main/java/io/mersel/dss/signer/api/util/SecurityProviderInitializer.java
+++ b/src/main/java/io/mersel/dss/signer/api/util/SecurityProviderInitializer.java
@@ -1,0 +1,34 @@
+package io.mersel.dss.signer.api.util;
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+
+import java.security.Security;
+
+/**
+ * BouncyCastle JCE provider'ının tek noktadan, idempotent şekilde kaydını sağlar.
+ *
+ * <p>Daha önce {@code CertificateFolderResolver} ve {@code AbstractKamuSMXmlDepoResolver}
+ * aynı {@code Security.addProvider(new BouncyCastleProvider())} çağrısını ayrı
+ * static bloklarda tekrarlıyordu. Burada toplanarak tekrar giderildi ve
+ * "zaten kayıtlıysa tekrar ekleme" güvencesi eklendi.</p>
+ *
+ * <p><b>Not:</b> Bu yardımcı, provider'ı listenin <i>sonuna</i> ekler (mevcut
+ * davranışın korunması için). {@code KeyStoreLoaderService} ise bilinçli olarak
+ * farklı bir kayıt yapar (BC'yi 1. sıraya alıp SunEC'i kaldırır); o özel mantık
+ * kasıtlı olduğundan buraya taşınmamıştır.</p>
+ */
+public final class SecurityProviderInitializer {
+
+    private SecurityProviderInitializer() {
+        // Utility class - örneklenmemeli
+    }
+
+    /**
+     * BouncyCastle provider'ı kayıtlı değilse ekler. Birden çok kez çağrılması güvenlidir.
+     */
+    public static void ensureBouncyCastle() {
+        if (Security.getProvider(BouncyCastleProvider.PROVIDER_NAME) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+}

--- a/src/main/java/io/mersel/dss/signer/api/util/Utilities.java
+++ b/src/main/java/io/mersel/dss/signer/api/util/Utilities.java
@@ -1,13 +1,6 @@
 package io.mersel.dss.signer.api.util;
 
 import io.mersel.dss.signer.api.util.xml.SecureXmlFactories;
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1Sequence;
-import org.bouncycastle.asn1.DERIA5String;
-import org.bouncycastle.asn1.x509.Extension;
-import org.bouncycastle.asn1.x509.GeneralName;
-import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
@@ -16,17 +9,15 @@ import org.xml.sax.SAXException;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
-import java.util.*;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipOutputStream;
+import java.util.Calendar;
+import java.util.Date;
 
 public class Utilities {
     private static final Logger LOGGER = LoggerFactory.getLogger(Utilities.class);
@@ -37,82 +28,12 @@ public class Utilities {
         return builder.parse(inputStream);
     }
 
-    public static byte[] ZipBytes(String filename, byte[] input) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        ZipOutputStream zos = new ZipOutputStream(baos);
-        ZipEntry entry = new ZipEntry(filename);
-
-        entry.setSize(input.length);
-        zos.putNextEntry(entry);
-        zos.write(input);
-        zos.closeEntry();
-        zos.close();
-        return baos.toByteArray();
-    }
-
-    public static List<X509Certificate> BuildCertificateChainOnline(X509Certificate cert) throws Exception {
-        List<X509Certificate> chain = new ArrayList<>();
-        chain.add(cert);
-
-        X509Certificate issuerCert;
-        while ((issuerCert = fetchIssuerCertificate(cert)) != null) {
-            chain.add(issuerCert);
-            cert = issuerCert;
-
-            if (cert.getSubjectX500Principal().equals(cert.getIssuerX500Principal())) {
-                LOGGER.info("✅ Root CA'ya ulaşıldı: {}", cert.getSubjectX500Principal());
-                break;
-            }
-        }
-
-        return chain;
-    }
-
-    private static X509Certificate fetchIssuerCertificate(X509Certificate cert) throws Exception {
-        String aiaUrl = getAiaIssuerUrl(cert);
-        if (aiaUrl == null) {
-            throw new Exception("Issuer sertifikası için AIA URL bulunamadı!");
-        }
-
-        LOGGER.info("📥 Issuer sertifikası indiriliyor: {}", aiaUrl);
-        return downloadCertificate(aiaUrl);
-    }
-
-    private static String getAiaIssuerUrl(X509Certificate cert) throws Exception {
-        byte[] aiaExt = cert.getExtensionValue(Extension.authorityInfoAccess.getId());
-        if (aiaExt == null) return null;
-
-        ASN1Sequence seq = ASN1Sequence.getInstance(JcaX509ExtensionUtils.parseExtensionValue(aiaExt));
-
-        for (ASN1Encodable encodable : seq.toArray()) {
-            ASN1Sequence subSeq = ASN1Sequence.getInstance(encodable);
-            if (subSeq.size() < 2) continue;
-
-            ASN1ObjectIdentifier id = (ASN1ObjectIdentifier) subSeq.getObjectAt(0);
-            if (id.getId().equals("1.3.6.1.5.5.7.48.2")) { // CA Issuer OID
-                GeneralName generalName = GeneralName.getInstance(subSeq.getObjectAt(1));
-                return ((DERIA5String) generalName.getName()).getString();
-            }
-        }
-        return null;
-    }
-
-    private static X509Certificate downloadCertificate(String urlStr) throws Exception {
-        URL url = new URL(urlStr);
-        try (InputStream in = url.openStream()) {
-            CertificateFactory cf = CertificateFactory.getInstance("X.509");
-            return (X509Certificate) cf.generateCertificate(in);
-        }
-    }
-
-
     public static X509Certificate LoadX509Certificate(String filePath) throws Exception {
         try (InputStream in = Files.newInputStream(Paths.get(filePath))) {
             CertificateFactory factory = CertificateFactory.getInstance("X.509");
             return (X509Certificate) factory.generateCertificate(in);
         }
     }
-
 
     public static void CheckIsDateValid(X509Certificate cert) {
         Date certStartTime = cert.getNotBefore();
@@ -122,5 +43,50 @@ public class Utilities {
         if (!(now.after(certStartTime) && now.before(certEndTime))) {
             throw new RuntimeException("Certificate is not valid");
         }
+    }
+
+    /**
+     * Spring {@code @Value} ile gelen bir dosya/klasör yolunu normalize eder:
+     * <ul>
+     *   <li>baştaki/sondaki eşleşen tek veya çift tırnakları temizler,</li>
+     *   <li>yol ISO-8859-1 olarak yanlış decode edilmişse (mojibake) UTF-8'e onarır.</li>
+     * </ul>
+     * {@code CertificateFolderResolver} ve {@code KamuSMXmlDepoOfflineResolver}
+     * aynı mantığı paylaştığı için burada tek noktada toplanmıştır.
+     *
+     * @param path ham yapılandırma değeri (null olabilir)
+     * @return normalize edilmiş yol (girdi null ise null)
+     */
+    public static String sanitizeConfiguredPath(String path) {
+        if (path == null) {
+            return null;
+        }
+        path = path.trim();
+        // Çift tırnak veya tek tırnak ile başlayıp bitiyorsa kaldır
+        if (path.length() >= 2 &&
+                ((path.startsWith("\"") && path.endsWith("\"")) ||
+                 (path.startsWith("'") && path.endsWith("'")))) {
+            path = path.substring(1, path.length() - 1);
+        }
+        // Encoding sorununu çöz: path ISO-8859-1 olarak yanlış okunduysa UTF-8'e çevir
+        // Örnek: "Ã–n" -> "Ön", "HazÄ±rlÄ±k" -> "Hazırlık"
+        try {
+            if (path.contains("Ã") || path.contains("Ä")) {
+                byte[] bytes = path.getBytes(StandardCharsets.ISO_8859_1);
+                String correctedPath = new String(bytes, StandardCharsets.UTF_8);
+                if (correctedPath.contains("Ö") || correctedPath.contains("ö") ||
+                    correctedPath.contains("ı") || correctedPath.contains("İ") ||
+                    correctedPath.contains("ş") || correctedPath.contains("Ş") ||
+                    correctedPath.contains("ğ") || correctedPath.contains("Ğ") ||
+                    correctedPath.contains("ü") || correctedPath.contains("Ü") ||
+                    correctedPath.contains("ç") || correctedPath.contains("Ç")) {
+                    path = correctedPath;
+                    LOGGER.debug("Yapılandırılan yol encoding düzeltildi: {}", path);
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.debug("Yol encoding düzeltme hatası: {}", e.getMessage());
+        }
+        return path;
     }
 }

--- a/src/test/java/io/mersel/dss/signer/api/GlobalExceptionHandlerTest.java
+++ b/src/test/java/io/mersel/dss/signer/api/GlobalExceptionHandlerTest.java
@@ -232,5 +232,45 @@ class GlobalExceptionHandlerTest {
         assertTrue(response.getBody().getMessage().contains("multipart/form-data"),
             "Client'a doğru Content-Type'ı işaret eden mesaj olmalı");
     }
+
+    /**
+     * G-6: Uygulama {@link io.mersel.dss.signer.api.exceptions.KeyStoreException}
+     * mesajı keystore dosya yolu/alias gibi iç detay taşısa bile HTTP yanıtına
+     * bu detay sızmamalı (sadece sunucu log'una gider).
+     */
+    @Test
+    void testHandleKeyStoreException_doesNotLeakInternalDetail() {
+        io.mersel.dss.signer.api.exceptions.KeyStoreException exception =
+            new io.mersel.dss.signer.api.exceptions.KeyStoreException(
+                "PFX keystore yüklenemedi: /etc/secrets/kurum01.pfx");
+
+        ResponseEntity<ErrorModel> response =
+            exceptionHandler.handleKeyStoreException(exception);
+
+        assertEquals("KEYSTORE_ERROR", response.getBody().getCode());
+        assertFalse(response.getBody().getMessage().contains("/etc/secrets"),
+            "Dosya sistemi yolu HTTP yanıtına sızmamalı");
+        assertFalse(response.getBody().getMessage().contains(".pfx"),
+            "Keystore dosya adı HTTP yanıtına sızmamalı");
+    }
+
+    /**
+     * G-7: JCA güvenlik exception'larının ham mesajı (yanlış PIN, alias vb.)
+     * HTTP yanıtında ifşa edilmemeli.
+     */
+    @Test
+    void testHandleSecurityException_doesNotLeakExceptionMessage() {
+        Exception exception =
+            new UnrecoverableKeyException("alias=muhur-2024 icin yanlis PIN girildi");
+
+        ResponseEntity<ErrorModel> response =
+            exceptionHandler.handleSecurityException(exception);
+
+        assertEquals("SECURITY_ERROR", response.getBody().getCode());
+        assertFalse(response.getBody().getMessage().contains("PIN"),
+            "Ham güvenlik hatası detayı HTTP yanıtına sızmamalı");
+        assertFalse(response.getBody().getMessage().contains("alias"),
+            "Alias bilgisi HTTP yanıtına sızmamalı");
+    }
 }
 


### PR DESCRIPTION
## 📝 Değişiklik Açıklaması

İmza sunucusunda tespit edilen thread-safety, kaynak sızıntısı, DoS ve bilgi-ifşası
sorunlarını düzelten; ayrıca ölü kod ve tekrar eden kodu temizleyen bir sağlamlaştırma
(hardening) PR'ı. Davranış çıktıları (imza formatı vb.) korunur; değişiklikler
eşzamanlılık güvenliği, güvenlik duruşu ve kod kalitesi odaklıdır.

**Başlıca düzeltmeler:**
- **Thread-safety:** `TimestampService` singleton'ında paylaşılan `SimpleDateFormat`
  (thread-safe değil) yerine immutable `DateTimeFormatter`; paralel timestamp
  isteklerinde bozuk tarih / `ArrayIndexOutOfBoundsException` riski giderildi.
- **Trusted-root cache:** `AbstractKamuSMXmlDepoResolver` ve `CertificateFolderResolver`
  içindeki `trustedCertificateSource` artık `volatile` + her yenilemede "build-and-swap";
  senkronizasyonsuz mutasyon yarışı çözüldü ve depodan/klasörden kaldırılan kök artık
  gerçekten güven listesinden düşüyor (önceden yalnızca ekleniyordu).
- **Kaynak sızıntısı:** `PAdESSignatureService` hata yolunda sızan `PdfReader`'ı `finally`
  ile kapatıyor (Windows'ta temp-file handle sızıntısı).
- **DoS (zip bomb):** `CompressionService.unzipFirstEntry` açılan içeriğe 100 MB üst
  sınır getirdi; ayrıca sıkıştırma stream'leri try-with-resources ile kapatılıyor.
- **Off-by-one:** `KamuSMXmlDepoOfflineResolver` — `length() >= 2` sonrası `charAt(2)`
  okuması `C:` gibi 2 karakterlik yolda `StringIndexOutOfBoundsException` fırlatıyordu.
- **Bilgi ifşası :** Hata yanıtları artık dosya sistemi yolu, HSM kütüphane yolu,
  keystore alias/serial ve ham exception mesajı sızdırmıyor (`GlobalExceptionHandler`,
  `CertificateInfoController`); detay yalnızca sunucu log'una gidiyor.
- **Fail-closed doğrulama ():** `SignatureValidationService` artık analiz sırasında
  hata olduğunda veya imza sertifikasının güvenilir köke ulaştığı gösterilemediğinde
  imzayı "kabul edilebilir" saymak yerine reddediyor.
- **Güvenlik uyarısı (#1 kısmi):** `KamuSMXmlDepoOnlineResolver` güven listesini düz HTTP
  üzerinden çekiyorsa belirgin bir MITM uyarısı loglanıyor.

**Temizlik / refactor:**
- `XmlConstants` sabitleri `public static final` + private constructor.
- Ölü kod kaldırıldı: `Utilities.ZipBytes`, `Utilities.BuildCertificateChainOnline`
  (ve yalnızca onun kullandığı `fetchIssuerCertificate`/`getAiaIssuerUrl`/`downloadCertificate`).
- Tekrar eden yol-normalizasyon mantığı `Utilities.sanitizeConfiguredPath` altında toplandı
  (iki resolver kullanıyor); hex kodlama `CryptoUtils.bytesToHex` altında toplandı
  (`SignerNotifier`); iki resolver'ın aynı BouncyCastle kaydı `SecurityProviderInitializer`
  ile tek noktaya alındı.
- Charset düzeltmeleri (platform default yerine `StandardCharsets.UTF_8`) ve ölü import temizliği.

## 🔗 İlgili Issue

## 🎯 Değişiklik Türü

- [x] 🐛 Bug fix (geriye uyumlu hata düzeltmesi)
- [ ] ✨ Yeni özellik (geriye uyumlu yeni işlevsellik)
- [ ] 💥 Breaking change (geriye uyumsuz değişiklik)
- [ ] 📝 Dokümantasyon güncellesi
- [x] ♻️ Refactoring (davranış değişikliği olmadan kod iyileştirme)
- [ ] ⚡ Performance iyileştirmesi
- [x] 🧪 Test ekleme/güncelleme

## 🧪 Testler

- [x] Yeni unit testler eklendi
- [x] Mevcut testler güncellendi
- [ ] Tüm testler başarılı (`mvn test`)   <!-- CI'da doğrulanacak; aşağıdaki nota bakın -->
- [ ] Manuel olarak test edildi

Değiştirilen alanları kapsayan birim testleri yerelde koşuldu ve **hepsi geçti**:
`CryptoUtilsTest`, `CryptoUtilsSignatureAlgorithmTest`, `TimestampServiceTest`,
`TimestampServiceContractTest`, `SignerNotifierTest`, `PAdESSignatureServiceTest`,
`RawHashSignatureServiceTest`, `CertificateInfoServiceTest`, `GlobalExceptionHandlerTest`.
`GlobalExceptionHandlerTest`'e bilgi-ifşasını engelleyen 2 yeni regresyon testi eklendi
(13/13 geçiyor). `mvn clean compile` tüm kaynakta hatasız.

## 📋 Kontrol Listesi

- [x] Kod standartlarına uygun (Javadoc, isimlendirme)
- [x] Commit mesajları açıklayıcı
- [ ] CHANGELOG.md güncellendi (major değişiklikler için)
- [ ] README.md güncellendi (gerekirse)
- [x] Linter hataları yok
- [ ] Breaking change ise migration guide eklendi

## 📸 Ekran Görüntüleri (varsa)

Yok (API sözleşmesi/UI görseli gerektiren değişiklik değil).

## 🔍 Test Senaryoları

1. **Timestamp thread-safety:** Zaman damgası uçları eşzamanlı çağrıldığında tarih
   alanlarının bozulmadığı (immutable `DateTimeFormatter`); çıktı biçimi
   `yyyy-MM-dd'T'HH:mm:ss'Z'` (UTC) aynen korunuyor — `TimestampService*Test` yeşil.
2. **Hata yanıtı sızıntısı:** `KeyStoreException` mesajı dosya yolu içerse bile HTTP
   yanıtına yol/alias/PIN sızmıyor — `GlobalExceptionHandlerTest` (2 yeni test) yeşil.
3. **PAdES kaynak yönetimi / raw-hash imza:** `PAdESSignatureServiceTest`,
   `RawHashSignatureServiceTest` yeşil.
4. **Hex tutarlılığı:** HMAC/SHA-256 hex çıktısı `CryptoUtils.bytesToHex`'e taşındıktan
   sonra da bit-birebir aynı — `SignerNotifierTest`, `CryptoUtilsTest` yeşil.
5. **Zip-bomb:** Aşırı sıkıştırılmış girdi 100 MB sınırında güvenli hata veriyor
   (meşru e-fatura/e-arşiv içerikleri sınırın çok altında).

## 💭 Ek Notlar

- **Davranış notu —  (fail-closed doğrulama):** Bu değişikliğin birim testi yok;
  davranışı yalnızca `verifier-e2e` grubundaki E2E testleri kapsıyor (bunlar `mvn test`'te
  varsayılan dışlanır ve `mersel-verifier-api` gerektirir). Merge öncesi lütfen
  `mvn -Dgroups=verifier-e2e -DexcludedGroups= test` ile pozitif (geçerli imza)
  senaryolarının hâlâ geçtiğini doğrulayın.
- **API notu —(`/api/certificates/info`):** Yanıttan `pfxPath` ve `library`
  (HSM kütüphane yolu) alanları güvenlik gerekçesiyle çıkarıldı. Bu alanları kullanan bir
  istemci varsa küçük bir uyumsuzluk oluşabilir; bilgi amaçlı iç yerleşim ifşası olduğu için
  kaldırıldı (`keystoreType`, `slot`, `certificateAlias`, `certificateSerialNumber` kaldı).
- **Kasıtlı dokunulmayanlar (maintainer kararı gerektiriyor):**
  (a) Uçlarda kimlik doğrulama yok — mimari/politika kararı;
  (b) `#1` güven listesi URL'i http→https: KamuSM deposu ilgili uçta HTTPS sunmadığı için
  (bağlantı reddediliyor) URL değiştirilmedi, yalnızca uyarı eklendi — kalıcı çözüm imzalı/pinlenmiş
  kaynak veya offline resolver;
  (c) deki güven-kökü kimliğinin DN-string ile belirlenmesi: `cert.isTrusted()` tabanlı bir
  yeniden tasarım daha güvenli olur ama `CertificateVerifier` yapılandırmasına bağlı olduğundan
  bilinçli olarak dokunulmadı;
  (d) BouncyCastle kaydında `KeyStoreLoaderService` ek olarak SunEC'i kaldırdığı (dokümante EC
  regresyon uyarılarıyla) için o özel mantık merkezileştirmeye dahil edilmedi.
- Java 8 uyumluluğu korundu (yalnızca `java.time`, try-with-resources gibi Java 8+ API'ler).
  Yerelde JDK 8 olmadığından derleme/test `-Djava.version=21` override'ı ile koşuldu; kaynak
  1.8 uyumlu.